### PR TITLE
ci: correct examples changed-files condition

### DIFF
--- a/.github/workflows/examples_component.yml
+++ b/.github/workflows/examples_component.yml
@@ -30,7 +30,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     outputs:
-      run-build: ${{ steps.force.outputs.force || steps.check-example-changes.outputs.changed_keys.components }}
+      run-build: ${{ steps.force.outputs.force || steps.check-example-changes.outputs.any_changed }}
     steps:
       - name: Force build if needed
         id: force


### PR DESCRIPTION
Pipeline was looking for a named set of file changes, but we're just using the `files:` input instead of the `files_yaml:` one which doesn't create named groups.

Build check:
https://github.com/wasmCloud/typescript/blob/6845206ed80484cbf139cb56f64abcc11e84b083/.github/workflows/examples_component.yml#L47-L55

Build condition:
https://github.com/wasmCloud/typescript/blob/6845206ed80484cbf139cb56f64abcc11e84b083/.github/workflows/examples_component.yml#L33