### PR TITLE
chore(ci): use github app for generating token

### DIFF
--- a/.github/workflows/ci_.yml
+++ b/.github/workflows/ci_.yml
@@ -34,6 +34,8 @@ jobs:
     needs: [build, test]
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      BOT_APP_ID: ${{ secrets.BOT_APP_ID }}
+      BOT_APP_PRIVATE_KEY: ${{ secrets.BOT_APP_PRIVATE_KEY }}
     permissions:
       contents: write       # Needed to commit changesets
       pull-requests: write  # Needed to create pull requests

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: CI - Build
 
 on:
   workflow_call: {}

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -1,17 +1,42 @@
-name: Release
+name: CI - Release
 
 on:
   workflow_call:
     secrets:
       NPM_TOKEN:
-        required: false
+        required: true
         description: NPM token for publishing packages
+      BOT_APP_ID:
+        required: true
+        description: GitHub App ID for creating tokens
+      BOT_APP_PRIVATE_KEY:
+        required: true
+        description: GitHub App private key for creating tokens
 
 permissions:
   contents: read
 
 jobs:
+  meta:
+    # Only run on main repo, don't try to release on forks
+    # Also only run on pushes to main branch, i.e. PRs and merge groups should not run this step
+    if: |
+      (github.repository == 'wasmCloud/typescript') &&
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    outputs:
+      GH_TOKEN: ${{ steps.app-token.outputs.token }}
+    steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
   changesets:
+    needs: [meta]
+
     permissions:
       contents: write       # Needed to commit changesets
       pull-requests: write  # Needed to create pull requests
@@ -40,7 +65,7 @@ jobs:
           version: yarn ci:version
           publish: yarn ci:publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ needs.meta.outputs.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Parse Published Packages

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: CI - Test
 
 on:
   workflow_call: {}

--- a/.github/workflows/examples_component.yml
+++ b/.github/workflows/examples_component.yml
@@ -1,4 +1,4 @@
-name: ci
+name: Examples - Component
 
 on:
   workflow_call:


### PR DESCRIPTION
Main changes are in `.github/workflows/ci_release.yml`. Added a `meta` job that only runs on push to main of this org repo.

Minor changes to naming for organization.