### PR TITLE
fix(dependabot): update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,16 @@
 version: 2
 updates:
+  # GitHub Actions/Workflows
+  - package-ecosystem: 'github-actions'
+    directory: '/.github'
+    schedule:
+      interval: 'daily'
+
+  # Published Packages
   - package-ecosystem: 'npm'
-    directory: '/'
+    directories: 
+      - '/packages/lattice-client-core'
+      - '/packages/lattice-client-react'
     schedule:
       interval: 'weekly'
       day: 'monday'
@@ -18,14 +27,47 @@ updates:
         update-types:
           - minor
           - patch
-  - package-ecosystem: 'github-actions'
-    directory: '/.github'
+
+  # Internal Packages
+  - package-ecosystem: 'npm'
+    directories: 
+      - '/packages/eslint-config'
+      - '/packages/prettier-config'
+      - '/packages/tsconfig'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'America/New_York'
     groups:
-      workflows:
-        patterns:
-          - '.github/workflows/*.yml'
-      actions:
-        patterns:
-          - '.github/actions/**/*.yml'
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      prod-dependencies:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+
+  # Apps
+  # - washboard-ui
+  - package-ecosystem: 'npm'
+    directory: '/apps/washboard'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'America/New_York'
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      prod-dependencies:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Dependabot is having issues.

https://github.com/wasmCloud/typescript/actions/runs/12746344007/job/35522160121
```
updater | 2025/01/13 11:34:28 WARN <job_946964647> Please check your configuration as there are groups where no dependencies match:
- workflows
- actions

This can happen if:
- the group's 'pattern' rules are misspelled
- your configuration's 'allow' rules do not permit any of the dependencies that match the group
- the dependencies that match the group rules have been removed from your project
```

and

https://github.com/wasmCloud/typescript/actions/runs/12750022040/job/35533829556
```
Error: The operation was canceled after 54m 58s
```

This breaks everything up into smaller chunks, so that it is easier to debug and fix.