### PR TITLE
fix(dependabot): remove duplicate groups from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,7 +54,7 @@ updates:
   # Apps
   # - washboard-ui
   - package-ecosystem: 'npm'
-    directory: '/apps/washboard'
+    directory: '/apps/washboard-ui'
     schedule:
       interval: 'weekly'
       day: 'monday'


### PR DESCRIPTION
Tried to make dependabot a little more organised, but nope. Yarn gets all messed up since dependabot doesn't check if it is in a workspace.