### PR TITLE
fix: move app checkout step to the front and use token for checkout

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -32,17 +32,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-
-      - name: Setup Node, Yarn, and Turbo
-        uses: ./.github/actions/ts-setup
-        with:
-          npm-token: ${{ secrets.NPM_TOKEN }}
-
-      - name: Build
-        run: yarn build
-
       - name: Get App Token
         id: app-token
         uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
@@ -61,6 +50,19 @@ jobs:
           git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
           git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>'
           git config --global format.signOff true
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Setup Node, Yarn, and Turbo
+        uses: ./.github/actions/ts-setup
+        with:
+          npm-token: ${{ secrets.NPM_TOKEN }}
+
+      - name: Build
+        run: yarn build
 
       - name: Version or Publish
         id: changesets


### PR DESCRIPTION
The changesets/action does not actually use the GITHUB_TOKEN for git operations, so we need to use the app token for the checkout step which sets up the git config.

See: https://github.com/changesets/action/issues/187#issuecomment-1228413850
