### PR TITLE
chore(ci): Replace tj-actions/changed-files action

### DIFF
--- a/.github/workflows/examples_.yml
+++ b/.github/workflows/examples_.yml
@@ -17,30 +17,26 @@ jobs:
   meta:
     runs-on: ubuntu-latest
     outputs:
-      changes: ${{ steps.changes.outputs.changed_keys }}
-      changed-components: ${{ contains(steps.changes.outputs.changed_keys, 'components') }}
-      changed-providers: ${{ contains(steps.changes.outputs.changed_keys, 'providers') }}
-      changed-ci: ${{ contains(steps.changes.outputs.changed_keys, 'ci') }}
+      changed-components: ${{ steps.changes.outputs.components }}
+      changed-providers: ${{ steps.changes.outputs.providers }}
+      changed-ci: ${{ steps.changes.outputs.ci }}
       wash-version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Check for changes
         id: changes
-        uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b # v45.0.8
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         with:
-          matrix: true
-          dir_names: true
-          dir_names_max_depth: 3
-          files_yaml: |
+          filters: |
             ci:
-              - .github/workflows/examples_.yml
-              - .github/workflows/examples_component.yml
-              - .github/workflows/examples_provider.yml
+              - '.github/workflows/examples_.yml'
+              - '.github/workflows/examples_component.yml'
+              - '.github/workflows/examples_provider.yml'
             components:
-              - examples/components/**
+              - 'examples/components/**'
             providers:
-              - examples/providers/**
+              - 'examples/providers/**'
 
       - name: Install `wash` CLI
         uses: taiki-e/install-action@e10e24b7664da3815cd5c17ed3865fbcd6cc1ed9 # v2.49.23

--- a/.github/workflows/examples_component.yml
+++ b/.github/workflows/examples_component.yml
@@ -30,7 +30,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     outputs:
-      run-build: ${{ steps.force.outputs.force || steps.check-example-changes.outputs.any_changed }}
+      run-build: ${{ steps.force.outputs.force || steps.check-example-changes.outputs.changed == 'true' }}
     steps:
       - name: Force build if needed
         id: force
@@ -47,12 +47,13 @@ jobs:
       - name: Check for Example Changes
         id: check-example-changes
         if : ${{ !inputs.force }}
-        uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b # v45.0.8
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         with:
-          files: |
-            .github/workflows/ci_examples.yml
-            .github/workflows/example_component.yml
-            examples/components/${{ inputs.folder }}/** 
+          filters: |
+            changed:
+              - '.github/workflows/ci_examples.yml'
+              - '.github/workflows/example_component.yml'
+              - 'examples/components/${{ inputs.folder }}/**'
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Feature or Problem

While we're unaffected by the SHA (`0e58ed8671d6b60d0890c21b07f8835ace038e67`) identified by Step Security, we need to stop using the action in question.

For more context, see:

* https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised
* https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
