### PR TITLE
chore(ci): prevent workflow running on main from cancelling when not a PR

### DIFF
--- a/.github/workflows/ci_.yml
+++ b/.github/workflows/ci_.yml
@@ -14,8 +14,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: washboard-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:


### PR DESCRIPTION
We don't want builds on main to get cancelled. They should release all the way through regardless id there is a newer commit on the branch.