### PR TITLE
chore(ci): add default empty json for missing job output

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -96,10 +96,10 @@ jobs:
 
   washboard-ui:
     needs: [changesets]
-    if: ${{ contains(fromJson(needs.changesets.outputs.publishedPackages).*.name, 'washboard-ui') }}
+    if: ${{ contains(fromJson(needs.changesets.outputs.publishedPackages || '{}').*.name, 'washboard-ui') }}
     permissions:
       contents: write
     uses: ./.github/workflows/release_washboard-ui.yml
     with:
-      version: ${{ fromJson(needs.changesets.outputs.packageVersions).washboard-ui }}
+      version: ${{ fromJson(needs.changesets.outputs.packageVersions || '{}').washboard-ui }}
       


### PR DESCRIPTION
As in [this run](https://github.com/wasmCloud/typescript/actions/runs/14633312779), the `ci_release` job is failing with the error:

```
wasmCloud/typescript/.github/workflows/ci_release.yml@1e7585307ebe66c7be5243591a8685dc46e9d6a4 (Line: 104, Col: 16): could not get operand for index access: Error from function 'fromJson': empty input
```

This PR adds a fallback JSON value as a string so that the `fromJson` function can be called without error.