### PR TITLE
[example] Update hono example with route that pulls from config values

### DIFF
--- a/.github/workflows/examples_.yml
+++ b/.github/workflows/examples_.yml
@@ -89,9 +89,18 @@ jobs:
             build-path: dist
             wasm-bin: http_server_with_hono_s.wasm
             test-command: |
-              EXPECTED="This is some JSON data."
-              RESPONSE=$(curl http://127.0.0.1:8000/api/data | jq -r '.message')
-              [[ "$RESPONSE" == "$EXPECTED" ]] && TEST_RESULT=1 || TEST_RESULT=0
+              # Test the /api/data route
+              EXPECTED_DATA="This is some JSON data."
+              RESPONSE_DATA=$(curl http://127.0.0.1:8000/api/data | jq -r '.message')
+              [[ "$RESPONSE_DATA" == "$EXPECTED_DATA" ]] && TEST_DATA=1 || TEST_DATA=0
+
+              # Test the /api/config route
+              EXPECTED_CONFIG='{"theme":"dark","version":"1.0.0","features":["logging","metrics"]}'
+              RESPONSE_CONFIG=$(curl http://127.0.0.1:8000/api/config)
+              [[ "$RESPONSE_CONFIG" == "$EXPECTED_CONFIG" ]] && TEST_CONFIG=1 || TEST_CONFIG=0
+
+              # Check that both data and config routes pass
+              [[ "$TEST_DATA" == '1' && "$TEST_CONFIG" == '1' ]] && TEST_RESULT=1 || TEST_RESULT=0
 
           - folder: http-streaming
             wasm-bin: http_streaming_s.wasm

--- a/examples/components/http-server-with-hono/local.wadm.yaml
+++ b/examples/components/http-server-with-hono/local.wadm.yaml
@@ -22,8 +22,9 @@ spec:
         config:
           - name: custom-config
             properties:
-              example: 'example'
               log_level: 'info'
+              # Example JSON config, see index.ts for usage
+              public_config_json: '{"theme": "dark", "version": "1.0.0", "features": ["logging", "metrics"]}'
       traits:
         - type: spreadscaler
           properties:

--- a/examples/components/http-server-with-hono/src/index.ts
+++ b/examples/components/http-server-with-hono/src/index.ts
@@ -13,6 +13,14 @@ app.use(wasiLog());
 app.get('/', (c: Context) => c.text('Welcome to the Hono HTTP Router Example!'));
 app.get('/hello', (c: Context) => c.text('Hello, World!'));
 app.get('/api/data', (c: Context) => c.json({message: 'This is some JSON data.'}));
+app.get('/api/config', (c: Context) => {
+  try {
+    const config = JSON.parse(c.env.public_config_json);
+    return c.json(config);
+  } catch (error) {
+    return c.json({error: 'Failed to parse config JSON'}, 500);
+  }
+});
 
 // handle missing routes
 app.notFound((c: Context) => {


### PR DESCRIPTION
The hono example doesn't make use of the config values in a clear way for custom data. This PR adds an example (and a test) that show how to pull custom data out of component runtime config.
