### PR TITLE
[example] Use `local.wadm.yaml` for `wash dev`

### DIFF
--- a/examples/components/http-server-with-hono/wasmcloud.toml
+++ b/examples/components/http-server-with-hono/wasmcloud.toml
@@ -10,3 +10,7 @@ wasm_target = "wasm32-wasip2"
 build_command = "npm run install-and-build"
 build_artifact = "dist/http_server_with_hono.wasm"
 destination = "dist/http_server_with_hono_s.wasm"
+
+[[dev.manifests]]
+component_name = "typescript-http-server-with-hono"
+path = "local.wadm.yaml"


### PR DESCRIPTION
## Feature or Problem
When using `wash dev`, there isn't yet a way to add runtime config to a component directly (see wasmcloud/wasmcloud#4522).

This PR makes wash dev use the local wadm manifest instead of generating it's own.

## Related Issues
This won't work until relative file support is added to wash dev. (wasmcloud/wasmcloud#4570)