### PR TITLE
fix: Add missing project generate

### DIFF
--- a/examples/components/http-hello-world/project-generate.toml
+++ b/examples/components/http-hello-world/project-generate.toml
@@ -1,0 +1,9 @@
+[template]
+
+raw = [
+  "*.wasm"
+]
+exclude = [
+  "gen/",
+  "keys/"
+]


### PR DESCRIPTION
We were missing the correct file for using the example as a template
