### PR TITLE
chore(templates): drop unused @ts-expect-error from WIT imports

### DIFF
--- a/templates/http-api-with-distributed-workloads/http-api/src/component.ts
+++ b/templates/http-api-with-distributed-workloads/http-api/src/component.ts
@@ -17,7 +17,6 @@
  *   const reply = request(subject, body, timeoutMs);
  */
 
-// @ts-expect-error — types generated after running npm run setup:wit
 import { request } from 'wasmcloud:messaging/consumer@0.2.0';
 import UI_HTML from './index.html?raw';
 

--- a/templates/http-api-with-distributed-workloads/task-worker/src/component.ts
+++ b/templates/http-api-with-distributed-workloads/task-worker/src/component.ts
@@ -18,18 +18,8 @@
  *   a named export object `handler` with a `handleMessage` method.
  */
 
-// @ts-expect-error — types generated after running npm run setup:wit
 import { publish } from 'wasmcloud:messaging/consumer@0.2.0';
-
-// ---------------------------------------------------------------------------
-// Types (inlined; generated types may appear after npm run setup:wit)
-// ---------------------------------------------------------------------------
-
-interface BrokerMessage {
-  subject: string;
-  body: Uint8Array;
-  replyTo?: string;
-}
+import type { BrokerMessage } from 'wasmcloud:messaging/types@0.2.0';
 
 // ---------------------------------------------------------------------------
 // Constants

--- a/templates/http-blobstore-service-hono/src/routes/items.ts
+++ b/templates/http-blobstore-service-hono/src/routes/items.ts
@@ -2,9 +2,7 @@ import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { z } from 'zod/mini';
 
-// @ts-expect-error - JCO doesn't generate types for wasi:blobstore yet
 import { getContainer, createContainer, containerExists } from 'wasi:blobstore/blobstore@0.2.0-draft';
-// @ts-expect-error - JCO doesn't generate types for wasi:blobstore yet
 import { OutgoingValue, IncomingValue } from 'wasi:blobstore/types@0.2.0-draft';
 
 // Validation schemas

--- a/templates/http-kv-service-hono/src/routes/items.ts
+++ b/templates/http-kv-service-hono/src/routes/items.ts
@@ -2,9 +2,7 @@ import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { z } from 'zod/mini';
 
-// @ts-expect-error - JCO doesn't generate types for wasi:keyvalue yet
 import { open } from 'wasi:keyvalue/store@0.2.0-draft';
-// @ts-expect-error - JCO doesn't generate types for wasi:keyvalue yet
 import { increment } from 'wasi:keyvalue/atomics@0.2.0-draft';
 
 // Validation schemas

--- a/templates/service-tcp-echo/component/generated/types/interfaces/wasi-clocks-monotonic-clock.d.ts
+++ b/templates/service-tcp-echo/component/generated/types/interfaces/wasi-clocks-monotonic-clock.d.ts
@@ -1,8 +1,10 @@
-/** @module Interface wasi:clocks/monotonic-clock@0.2.3 **/
-export function now(): Instant;
-export function resolution(): Duration;
-export function subscribeInstant(when: Instant): Pollable;
-export function subscribeDuration(when: Duration): Pollable;
-export type Pollable = import('./wasi-io-poll.js').Pollable;
-export type Instant = bigint;
-export type Duration = bigint;
+/// <reference path="./wasi-io-poll.d.ts" />
+declare module 'wasi:clocks/monotonic-clock@0.2.3' {
+  export function now(): Instant;
+  export function resolution(): Duration;
+  export function subscribeInstant(when: Instant): Pollable;
+  export function subscribeDuration(when: Duration): Pollable;
+  export type Pollable = import('wasi:io/poll@0.2.3').Pollable;
+  export type Instant = bigint;
+  export type Duration = bigint;
+}

--- a/templates/service-tcp-echo/component/generated/types/interfaces/wasi-http-incoming-handler.d.ts
+++ b/templates/service-tcp-echo/component/generated/types/interfaces/wasi-http-incoming-handler.d.ts
@@ -1,16 +1,18 @@
-/** @module Interface wasi:http/incoming-handler@0.2.6 **/
-/**
- * This function is invoked with an incoming HTTP Request, and a resource
- * `response-outparam` which provides the capability to reply with an HTTP
- * Response. The response is sent by calling the `response-outparam.set`
- * method, which allows execution to continue after the response has been
- * sent. This enables both streaming to the response body, and performing other
- * work.
- * 
- * The implementor of this function must write a response to the
- * `response-outparam` before returning, or else the caller will respond
- * with an error on its behalf.
- */
-export function handle(request: IncomingRequest, responseOut: ResponseOutparam): void;
-export type IncomingRequest = import('./wasi-http-types.js').IncomingRequest;
-export type ResponseOutparam = import('./wasi-http-types.js').ResponseOutparam;
+/// <reference path="./wasi-http-types.d.ts" />
+declare module 'wasi:http/incoming-handler@0.2.6' {
+  /**
+   * This function is invoked with an incoming HTTP Request, and a resource
+   * `response-outparam` which provides the capability to reply with an HTTP
+   * Response. The response is sent by calling the `response-outparam.set`
+   * method, which allows execution to continue after the response has been
+   * sent. This enables both streaming to the response body, and performing other
+   * work.
+   * 
+   * The implementor of this function must write a response to the
+   * `response-outparam` before returning, or else the caller will respond
+   * with an error on its behalf.
+   */
+  export function handle(request: IncomingRequest, responseOut: ResponseOutparam): void;
+  export type IncomingRequest = import('wasi:http/types@0.2.6').IncomingRequest;
+  export type ResponseOutparam = import('wasi:http/types@0.2.6').ResponseOutparam;
+}

--- a/templates/service-tcp-echo/component/generated/types/interfaces/wasi-http-types.d.ts
+++ b/templates/service-tcp-echo/component/generated/types/interfaces/wasi-http-types.d.ts
@@ -1,748 +1,764 @@
-/** @module Interface wasi:http/types@0.2.6 **/
-/**
- * Attempts to extract a http-related `error` from the wasi:io `error`
- * provided.
- * 
- * Stream operations which return
- * `wasi:io/stream/stream-error::last-operation-failed` have a payload of
- * type `wasi:io/error/error` with more information about the operation
- * that failed. This payload can be passed through to this function to see
- * if there's http-related information about the error to return.
- * 
- * Note that this function is fallible because not all io-errors are
- * http-related errors.
- */
-export function httpErrorCode(err: IoError): ErrorCode | undefined;
-export type Duration = import('./wasi-clocks-monotonic-clock.js').Duration;
-export type InputStream = import('./wasi-io-streams.js').InputStream;
-export type OutputStream = import('./wasi-io-streams.js').OutputStream;
-export type IoError = import('./wasi-io-error.js').Error;
-export type Pollable = import('./wasi-io-poll.js').Pollable;
-/**
- * This type corresponds to HTTP standard Methods.
- */
-export type Method = MethodGet | MethodHead | MethodPost | MethodPut | MethodDelete | MethodConnect | MethodOptions | MethodTrace | MethodPatch | MethodOther;
-export interface MethodGet {
-  tag: 'get',
-}
-export interface MethodHead {
-  tag: 'head',
-}
-export interface MethodPost {
-  tag: 'post',
-}
-export interface MethodPut {
-  tag: 'put',
-}
-export interface MethodDelete {
-  tag: 'delete',
-}
-export interface MethodConnect {
-  tag: 'connect',
-}
-export interface MethodOptions {
-  tag: 'options',
-}
-export interface MethodTrace {
-  tag: 'trace',
-}
-export interface MethodPatch {
-  tag: 'patch',
-}
-export interface MethodOther {
-  tag: 'other',
-  val: string,
-}
-/**
- * This type corresponds to HTTP standard Related Schemes.
- */
-export type Scheme = SchemeHttp | SchemeHttps | SchemeOther;
-export interface SchemeHttp {
-  tag: 'HTTP',
-}
-export interface SchemeHttps {
-  tag: 'HTTPS',
-}
-export interface SchemeOther {
-  tag: 'other',
-  val: string,
-}
-/**
- * Defines the case payload type for `DNS-error` above:
- */
-export interface DnsErrorPayload {
-  rcode?: string,
-  infoCode?: number,
-}
-/**
- * Defines the case payload type for `TLS-alert-received` above:
- */
-export interface TlsAlertReceivedPayload {
-  alertId?: number,
-  alertMessage?: string,
-}
-/**
- * Defines the case payload type for `HTTP-response-{header,trailer}-size` above:
- */
-export interface FieldSizePayload {
-  fieldName?: string,
-  fieldSize?: number,
-}
-/**
- * These cases are inspired by the IANA HTTP Proxy Error Types:
- *   <https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types>
- */
-export type ErrorCode = ErrorCodeDnsTimeout | ErrorCodeDnsError | ErrorCodeDestinationNotFound | ErrorCodeDestinationUnavailable | ErrorCodeDestinationIpProhibited | ErrorCodeDestinationIpUnroutable | ErrorCodeConnectionRefused | ErrorCodeConnectionTerminated | ErrorCodeConnectionTimeout | ErrorCodeConnectionReadTimeout | ErrorCodeConnectionWriteTimeout | ErrorCodeConnectionLimitReached | ErrorCodeTlsProtocolError | ErrorCodeTlsCertificateError | ErrorCodeTlsAlertReceived | ErrorCodeHttpRequestDenied | ErrorCodeHttpRequestLengthRequired | ErrorCodeHttpRequestBodySize | ErrorCodeHttpRequestMethodInvalid | ErrorCodeHttpRequestUriInvalid | ErrorCodeHttpRequestUriTooLong | ErrorCodeHttpRequestHeaderSectionSize | ErrorCodeHttpRequestHeaderSize | ErrorCodeHttpRequestTrailerSectionSize | ErrorCodeHttpRequestTrailerSize | ErrorCodeHttpResponseIncomplete | ErrorCodeHttpResponseHeaderSectionSize | ErrorCodeHttpResponseHeaderSize | ErrorCodeHttpResponseBodySize | ErrorCodeHttpResponseTrailerSectionSize | ErrorCodeHttpResponseTrailerSize | ErrorCodeHttpResponseTransferCoding | ErrorCodeHttpResponseContentCoding | ErrorCodeHttpResponseTimeout | ErrorCodeHttpUpgradeFailed | ErrorCodeHttpProtocolError | ErrorCodeLoopDetected | ErrorCodeConfigurationError | ErrorCodeInternalError;
-export interface ErrorCodeDnsTimeout {
-  tag: 'DNS-timeout',
-}
-export interface ErrorCodeDnsError {
-  tag: 'DNS-error',
-  val: DnsErrorPayload,
-}
-export interface ErrorCodeDestinationNotFound {
-  tag: 'destination-not-found',
-}
-export interface ErrorCodeDestinationUnavailable {
-  tag: 'destination-unavailable',
-}
-export interface ErrorCodeDestinationIpProhibited {
-  tag: 'destination-IP-prohibited',
-}
-export interface ErrorCodeDestinationIpUnroutable {
-  tag: 'destination-IP-unroutable',
-}
-export interface ErrorCodeConnectionRefused {
-  tag: 'connection-refused',
-}
-export interface ErrorCodeConnectionTerminated {
-  tag: 'connection-terminated',
-}
-export interface ErrorCodeConnectionTimeout {
-  tag: 'connection-timeout',
-}
-export interface ErrorCodeConnectionReadTimeout {
-  tag: 'connection-read-timeout',
-}
-export interface ErrorCodeConnectionWriteTimeout {
-  tag: 'connection-write-timeout',
-}
-export interface ErrorCodeConnectionLimitReached {
-  tag: 'connection-limit-reached',
-}
-export interface ErrorCodeTlsProtocolError {
-  tag: 'TLS-protocol-error',
-}
-export interface ErrorCodeTlsCertificateError {
-  tag: 'TLS-certificate-error',
-}
-export interface ErrorCodeTlsAlertReceived {
-  tag: 'TLS-alert-received',
-  val: TlsAlertReceivedPayload,
-}
-export interface ErrorCodeHttpRequestDenied {
-  tag: 'HTTP-request-denied',
-}
-export interface ErrorCodeHttpRequestLengthRequired {
-  tag: 'HTTP-request-length-required',
-}
-export interface ErrorCodeHttpRequestBodySize {
-  tag: 'HTTP-request-body-size',
-  val: bigint | undefined,
-}
-export interface ErrorCodeHttpRequestMethodInvalid {
-  tag: 'HTTP-request-method-invalid',
-}
-export interface ErrorCodeHttpRequestUriInvalid {
-  tag: 'HTTP-request-URI-invalid',
-}
-export interface ErrorCodeHttpRequestUriTooLong {
-  tag: 'HTTP-request-URI-too-long',
-}
-export interface ErrorCodeHttpRequestHeaderSectionSize {
-  tag: 'HTTP-request-header-section-size',
-  val: number | undefined,
-}
-export interface ErrorCodeHttpRequestHeaderSize {
-  tag: 'HTTP-request-header-size',
-  val: FieldSizePayload | undefined,
-}
-export interface ErrorCodeHttpRequestTrailerSectionSize {
-  tag: 'HTTP-request-trailer-section-size',
-  val: number | undefined,
-}
-export interface ErrorCodeHttpRequestTrailerSize {
-  tag: 'HTTP-request-trailer-size',
-  val: FieldSizePayload,
-}
-export interface ErrorCodeHttpResponseIncomplete {
-  tag: 'HTTP-response-incomplete',
-}
-export interface ErrorCodeHttpResponseHeaderSectionSize {
-  tag: 'HTTP-response-header-section-size',
-  val: number | undefined,
-}
-export interface ErrorCodeHttpResponseHeaderSize {
-  tag: 'HTTP-response-header-size',
-  val: FieldSizePayload,
-}
-export interface ErrorCodeHttpResponseBodySize {
-  tag: 'HTTP-response-body-size',
-  val: bigint | undefined,
-}
-export interface ErrorCodeHttpResponseTrailerSectionSize {
-  tag: 'HTTP-response-trailer-section-size',
-  val: number | undefined,
-}
-export interface ErrorCodeHttpResponseTrailerSize {
-  tag: 'HTTP-response-trailer-size',
-  val: FieldSizePayload,
-}
-export interface ErrorCodeHttpResponseTransferCoding {
-  tag: 'HTTP-response-transfer-coding',
-  val: string | undefined,
-}
-export interface ErrorCodeHttpResponseContentCoding {
-  tag: 'HTTP-response-content-coding',
-  val: string | undefined,
-}
-export interface ErrorCodeHttpResponseTimeout {
-  tag: 'HTTP-response-timeout',
-}
-export interface ErrorCodeHttpUpgradeFailed {
-  tag: 'HTTP-upgrade-failed',
-}
-export interface ErrorCodeHttpProtocolError {
-  tag: 'HTTP-protocol-error',
-}
-export interface ErrorCodeLoopDetected {
-  tag: 'loop-detected',
-}
-export interface ErrorCodeConfigurationError {
-  tag: 'configuration-error',
-}
-/**
- * This is a catch-all error for anything that doesn't fit cleanly into a
- * more specific case. It also includes an optional string for an
- * unstructured description of the error. Users should not depend on the
- * string for diagnosing errors, as it's not required to be consistent
- * between implementations.
- */
-export interface ErrorCodeInternalError {
-  tag: 'internal-error',
-  val: string | undefined,
-}
-/**
- * This type enumerates the different kinds of errors that may occur when
- * setting or appending to a `fields` resource.
- */
-export type HeaderError = HeaderErrorInvalidSyntax | HeaderErrorForbidden | HeaderErrorImmutable;
-/**
- * This error indicates that a `field-name` or `field-value` was
- * syntactically invalid when used with an operation that sets headers in a
- * `fields`.
- */
-export interface HeaderErrorInvalidSyntax {
-  tag: 'invalid-syntax',
-}
-/**
- * This error indicates that a forbidden `field-name` was used when trying
- * to set a header in a `fields`.
- */
-export interface HeaderErrorForbidden {
-  tag: 'forbidden',
-}
-/**
- * This error indicates that the operation on the `fields` was not
- * permitted because the fields are immutable.
- */
-export interface HeaderErrorImmutable {
-  tag: 'immutable',
-}
-/**
- * Field keys are always strings.
- * 
- * Field keys should always be treated as case insensitive by the `fields`
- * resource for the purposes of equality checking.
- * 
- * # Deprecation
- * 
- * This type has been deprecated in favor of the `field-name` type.
- */
-export type FieldKey = string;
-/**
- * Field names are always strings.
- * 
- * Field names should always be treated as case insensitive by the `fields`
- * resource for the purposes of equality checking.
- */
-export type FieldName = FieldKey;
-/**
- * Field values should always be ASCII strings. However, in
- * reality, HTTP implementations often have to interpret malformed values,
- * so they are provided as a list of bytes.
- */
-export type FieldValue = Uint8Array;
-/**
- * Headers is an alias for Fields.
- */
-export type Headers = Fields;
-/**
- * Trailers is an alias for Fields.
- */
-export type Trailers = Fields;
-/**
- * This type corresponds to the HTTP standard Status Code.
- */
-export type StatusCode = number;
-export type Result<T, E> = { tag: 'ok', val: T } | { tag: 'err', val: E };
-
-export class Fields {
+/// <reference path="./wasi-clocks-monotonic-clock.d.ts" />
+/// <reference path="./wasi-io-error.d.ts" />
+/// <reference path="./wasi-io-poll.d.ts" />
+/// <reference path="./wasi-io-streams.d.ts" />
+declare module 'wasi:http/types@0.2.6' {
   /**
-  * Construct an empty HTTP Fields.
-  * 
-  * The resulting `fields` is mutable.
-  */
-  constructor()
-  /**
-  * Construct an HTTP Fields.
-  * 
-  * The resulting `fields` is mutable.
-  * 
-  * The list represents each name-value pair in the Fields. Names
-  * which have multiple values are represented by multiple entries in this
-  * list with the same name.
-  * 
-  * The tuple is a pair of the field name, represented as a string, and
-  * Value, represented as a list of bytes.
-  * 
-  * An error result will be returned if any `field-name` or `field-value` is
-  * syntactically invalid, or if a field is forbidden.
-  */
-  static fromList(entries: Array<[FieldName, FieldValue]>): Fields;
-  /**
-  * Get all of the values corresponding to a name. If the name is not present
-  * in this `fields` or is syntactically invalid, an empty list is returned.
-  * However, if the name is present but empty, this is represented by a list
-  * with one or more empty field-values present.
-  */
-  get(name: FieldName): Array<FieldValue>;
-  /**
-  * Returns `true` when the name is present in this `fields`. If the name is
-  * syntactically invalid, `false` is returned.
-  */
-  has(name: FieldName): boolean;
-  /**
-  * Set all of the values for a name. Clears any existing values for that
-  * name, if they have been set.
-  * 
-  * Fails with `header-error.immutable` if the `fields` are immutable.
-  * 
-  * Fails with `header-error.invalid-syntax` if the `field-name` or any of
-  * the `field-value`s are syntactically invalid.
-  */
-  set(name: FieldName, value: Array<FieldValue>): void;
-  /**
-  * Delete all values for a name. Does nothing if no values for the name
-  * exist.
-  * 
-  * Fails with `header-error.immutable` if the `fields` are immutable.
-  * 
-  * Fails with `header-error.invalid-syntax` if the `field-name` is
-  * syntactically invalid.
-  */
-  'delete'(name: FieldName): void;
-  /**
-  * Append a value for a name. Does not change or delete any existing
-  * values for that name.
-  * 
-  * Fails with `header-error.immutable` if the `fields` are immutable.
-  * 
-  * Fails with `header-error.invalid-syntax` if the `field-name` or
-  * `field-value` are syntactically invalid.
-  */
-  append(name: FieldName, value: FieldValue): void;
-  /**
-  * Retrieve the full set of names and values in the Fields. Like the
-  * constructor, the list represents each name-value pair.
-  * 
-  * The outer list represents each name-value pair in the Fields. Names
-  * which have multiple values are represented by multiple entries in this
-  * list with the same name.
-  * 
-  * The names and values are always returned in the original casing and in
-  * the order in which they will be serialized for transport.
-  */
-  entries(): Array<[FieldName, FieldValue]>;
-  /**
-  * Make a deep copy of the Fields. Equivalent in behavior to calling the
-  * `fields` constructor on the return value of `entries`. The resulting
-  * `fields` is mutable.
-  */
-  clone(): Fields;
-}
-
-export class FutureIncomingResponse {
-  /**
-   * This type does not have a public constructor.
+   * Attempts to extract a http-related `error` from the wasi:io `error`
+   * provided.
+   * 
+   * Stream operations which return
+   * `wasi:io/stream/stream-error::last-operation-failed` have a payload of
+   * type `wasi:io/error/error` with more information about the operation
+   * that failed. This payload can be passed through to this function to see
+   * if there's http-related information about the error to return.
+   * 
+   * Note that this function is fallible because not all io-errors are
+   * http-related errors.
    */
-  private constructor();
+  export function httpErrorCode(err: IoError): ErrorCode | undefined;
+  export type Duration = import('wasi:clocks/monotonic-clock@0.2.6').Duration;
+  export type InputStream = import('wasi:io/streams@0.2.6').InputStream;
+  export type OutputStream = import('wasi:io/streams@0.2.6').OutputStream;
+  export type IoError = import('wasi:io/error@0.2.6').Error;
+  export type Pollable = import('wasi:io/poll@0.2.6').Pollable;
   /**
-  * Returns a pollable which becomes ready when either the Response has
-  * been received, or an error has occurred. When this pollable is ready,
-  * the `get` method will return `some`.
-  */
-  subscribe(): Pollable;
-  /**
-  * Returns the incoming HTTP Response, or an error, once one is ready.
-  * 
-  * The outer `option` represents future readiness. Users can wait on this
-  * `option` to become `some` using the `subscribe` method.
-  * 
-  * The outer `result` is used to retrieve the response or error at most
-  * once. It will be success on the first call in which the outer option
-  * is `some`, and error on subsequent calls.
-  * 
-  * The inner `result` represents that either the incoming HTTP Response
-  * status and headers have received successfully, or that an error
-  * occurred. Errors may also occur while consuming the response body,
-  * but those will be reported by the `incoming-body` and its
-  * `output-stream` child.
-  */
-  get(): Result<Result<IncomingResponse, ErrorCode>, void> | undefined;
-}
-
-export class FutureTrailers {
-  /**
-   * This type does not have a public constructor.
+   * This type corresponds to HTTP standard Methods.
    */
-  private constructor();
+  export type Method = MethodGet | MethodHead | MethodPost | MethodPut | MethodDelete | MethodConnect | MethodOptions | MethodTrace | MethodPatch | MethodOther;
+  export interface MethodGet {
+    tag: 'get',
+  }
+  export interface MethodHead {
+    tag: 'head',
+  }
+  export interface MethodPost {
+    tag: 'post',
+  }
+  export interface MethodPut {
+    tag: 'put',
+  }
+  export interface MethodDelete {
+    tag: 'delete',
+  }
+  export interface MethodConnect {
+    tag: 'connect',
+  }
+  export interface MethodOptions {
+    tag: 'options',
+  }
+  export interface MethodTrace {
+    tag: 'trace',
+  }
+  export interface MethodPatch {
+    tag: 'patch',
+  }
+  export interface MethodOther {
+    tag: 'other',
+    val: string,
+  }
   /**
-  * Returns a pollable which becomes ready when either the trailers have
-  * been received, or an error has occurred. When this pollable is ready,
-  * the `get` method will return `some`.
-  */
-  subscribe(): Pollable;
-  /**
-  * Returns the contents of the trailers, or an error which occurred,
-  * once the future is ready.
-  * 
-  * The outer `option` represents future readiness. Users can wait on this
-  * `option` to become `some` using the `subscribe` method.
-  * 
-  * The outer `result` is used to retrieve the trailers or error at most
-  * once. It will be success on the first call in which the outer option
-  * is `some`, and error on subsequent calls.
-  * 
-  * The inner `result` represents that either the HTTP Request or Response
-  * body, as well as any trailers, were received successfully, or that an
-  * error occurred receiving them. The optional `trailers` indicates whether
-  * or not trailers were present in the body.
-  * 
-  * When some `trailers` are returned by this method, the `trailers`
-  * resource is immutable, and a child. Use of the `set`, `append`, or
-  * `delete` methods will return an error, and the resource must be
-  * dropped before the parent `future-trailers` is dropped.
-  */
-  get(): Result<Result<Trailers | undefined, ErrorCode>, void> | undefined;
-}
-
-export class IncomingBody {
-  /**
-   * This type does not have a public constructor.
+   * This type corresponds to HTTP standard Related Schemes.
    */
-  private constructor();
+  export type Scheme = SchemeHttp | SchemeHttps | SchemeOther;
+  export interface SchemeHttp {
+    tag: 'HTTP',
+  }
+  export interface SchemeHttps {
+    tag: 'HTTPS',
+  }
+  export interface SchemeOther {
+    tag: 'other',
+    val: string,
+  }
   /**
-  * Returns the contents of the body, as a stream of bytes.
-  * 
-  * Returns success on first call: the stream representing the contents
-  * can be retrieved at most once. Subsequent calls will return error.
-  * 
-  * The returned `input-stream` resource is a child: it must be dropped
-  * before the parent `incoming-body` is dropped, or consumed by
-  * `incoming-body.finish`.
-  * 
-  * This invariant ensures that the implementation can determine whether
-  * the user is consuming the contents of the body, waiting on the
-  * `future-trailers` to be ready, or neither. This allows for network
-  * backpressure is to be applied when the user is consuming the body,
-  * and for that backpressure to not inhibit delivery of the trailers if
-  * the user does not read the entire body.
-  */
-  stream(): InputStream;
-  /**
-  * Takes ownership of `incoming-body`, and returns a `future-trailers`.
-  * This function will trap if the `input-stream` child is still alive.
-  */
-  static finish(this_: IncomingBody): FutureTrailers;
-}
-
-export class IncomingRequest {
-  /**
-   * This type does not have a public constructor.
+   * Defines the case payload type for `DNS-error` above:
    */
-  private constructor();
+  export interface DnsErrorPayload {
+    rcode?: string,
+    infoCode?: number,
+  }
   /**
-  * Returns the method of the incoming request.
-  */
-  method(): Method;
-  /**
-  * Returns the path with query parameters from the request, as a string.
-  */
-  pathWithQuery(): string | undefined;
-  /**
-  * Returns the protocol scheme from the request.
-  */
-  scheme(): Scheme | undefined;
-  /**
-  * Returns the authority of the Request's target URI, if present.
-  */
-  authority(): string | undefined;
-  /**
-  * Get the `headers` associated with the request.
-  * 
-  * The returned `headers` resource is immutable: `set`, `append`, and
-  * `delete` operations will fail with `header-error.immutable`.
-  * 
-  * The `headers` returned are a child resource: it must be dropped before
-  * the parent `incoming-request` is dropped. Dropping this
-  * `incoming-request` before all children are dropped will trap.
-  */
-  headers(): Headers;
-  /**
-  * Gives the `incoming-body` associated with this request. Will only
-  * return success at most once, and subsequent calls will return error.
-  */
-  consume(): IncomingBody;
-}
-
-export class IncomingResponse {
-  /**
-   * This type does not have a public constructor.
+   * Defines the case payload type for `TLS-alert-received` above:
    */
-  private constructor();
+  export interface TlsAlertReceivedPayload {
+    alertId?: number,
+    alertMessage?: string,
+  }
   /**
-  * Returns the status code from the incoming response.
-  */
-  status(): StatusCode;
-  /**
-  * Returns the headers from the incoming response.
-  * 
-  * The returned `headers` resource is immutable: `set`, `append`, and
-  * `delete` operations will fail with `header-error.immutable`.
-  * 
-  * This headers resource is a child: it must be dropped before the parent
-  * `incoming-response` is dropped.
-  */
-  headers(): Headers;
-  /**
-  * Returns the incoming body. May be called at most once. Returns error
-  * if called additional times.
-  */
-  consume(): IncomingBody;
-}
-
-export class OutgoingBody {
-  /**
-   * This type does not have a public constructor.
+   * Defines the case payload type for `HTTP-response-{header,trailer}-size` above:
    */
-  private constructor();
+  export interface FieldSizePayload {
+    fieldName?: string,
+    fieldSize?: number,
+  }
   /**
-  * Returns a stream for writing the body contents.
-  * 
-  * The returned `output-stream` is a child resource: it must be dropped
-  * before the parent `outgoing-body` resource is dropped (or finished),
-  * otherwise the `outgoing-body` drop or `finish` will trap.
-  * 
-  * Returns success on the first call: the `output-stream` resource for
-  * this `outgoing-body` may be retrieved at most once. Subsequent calls
-  * will return error.
-  */
-  write(): OutputStream;
-  /**
-  * Finalize an outgoing body, optionally providing trailers. This must be
-  * called to signal that the response is complete. If the `outgoing-body`
-  * is dropped without calling `outgoing-body.finalize`, the implementation
-  * should treat the body as corrupted.
-  * 
-  * Fails if the body's `outgoing-request` or `outgoing-response` was
-  * constructed with a Content-Length header, and the contents written
-  * to the body (via `write`) does not match the value given in the
-  * Content-Length.
-  */
-  static finish(this_: OutgoingBody, trailers: Trailers | undefined): void;
-}
-
-export class OutgoingRequest {
-  /**
-  * Construct a new `outgoing-request` with a default `method` of `GET`, and
-  * `none` values for `path-with-query`, `scheme`, and `authority`.
-  * 
-  * * `headers` is the HTTP Headers for the Request.
-  * 
-  * It is possible to construct, or manipulate with the accessor functions
-  * below, an `outgoing-request` with an invalid combination of `scheme`
-  * and `authority`, or `headers` which are not permitted to be sent.
-  * It is the obligation of the `outgoing-handler.handle` implementation
-  * to reject invalid constructions of `outgoing-request`.
-  */
-  constructor(headers: Headers)
-  /**
-  * Returns the resource corresponding to the outgoing Body for this
-  * Request.
-  * 
-  * Returns success on the first call: the `outgoing-body` resource for
-  * this `outgoing-request` can be retrieved at most once. Subsequent
-  * calls will return error.
-  */
-  body(): OutgoingBody;
-  /**
-  * Get the Method for the Request.
-  */
-  method(): Method;
-  /**
-  * Set the Method for the Request. Fails if the string present in a
-  * `method.other` argument is not a syntactically valid method.
-  */
-  setMethod(method: Method): void;
-  /**
-  * Get the combination of the HTTP Path and Query for the Request.
-  * When `none`, this represents an empty Path and empty Query.
-  */
-  pathWithQuery(): string | undefined;
-  /**
-  * Set the combination of the HTTP Path and Query for the Request.
-  * When `none`, this represents an empty Path and empty Query. Fails is the
-  * string given is not a syntactically valid path and query uri component.
-  */
-  setPathWithQuery(pathWithQuery: string | undefined): void;
-  /**
-  * Get the HTTP Related Scheme for the Request. When `none`, the
-  * implementation may choose an appropriate default scheme.
-  */
-  scheme(): Scheme | undefined;
-  /**
-  * Set the HTTP Related Scheme for the Request. When `none`, the
-  * implementation may choose an appropriate default scheme. Fails if the
-  * string given is not a syntactically valid uri scheme.
-  */
-  setScheme(scheme: Scheme | undefined): void;
-  /**
-  * Get the authority of the Request's target URI. A value of `none` may be used
-  * with Related Schemes which do not require an authority. The HTTP and
-  * HTTPS schemes always require an authority.
-  */
-  authority(): string | undefined;
-  /**
-  * Set the authority of the Request's target URI. A value of `none` may be used
-  * with Related Schemes which do not require an authority. The HTTP and
-  * HTTPS schemes always require an authority. Fails if the string given is
-  * not a syntactically valid URI authority.
-  */
-  setAuthority(authority: string | undefined): void;
-  /**
-  * Get the headers associated with the Request.
-  * 
-  * The returned `headers` resource is immutable: `set`, `append`, and
-  * `delete` operations will fail with `header-error.immutable`.
-  * 
-  * This headers resource is a child: it must be dropped before the parent
-  * `outgoing-request` is dropped, or its ownership is transferred to
-  * another component by e.g. `outgoing-handler.handle`.
-  */
-  headers(): Headers;
-}
-
-export class OutgoingResponse {
-  /**
-  * Construct an `outgoing-response`, with a default `status-code` of `200`.
-  * If a different `status-code` is needed, it must be set via the
-  * `set-status-code` method.
-  * 
-  * * `headers` is the HTTP Headers for the Response.
-  */
-  constructor(headers: Headers)
-  /**
-  * Get the HTTP Status Code for the Response.
-  */
-  statusCode(): StatusCode;
-  /**
-  * Set the HTTP Status Code for the Response. Fails if the status-code
-  * given is not a valid http status code.
-  */
-  setStatusCode(statusCode: StatusCode): void;
-  /**
-  * Get the headers associated with the Request.
-  * 
-  * The returned `headers` resource is immutable: `set`, `append`, and
-  * `delete` operations will fail with `header-error.immutable`.
-  * 
-  * This headers resource is a child: it must be dropped before the parent
-  * `outgoing-request` is dropped, or its ownership is transferred to
-  * another component by e.g. `outgoing-handler.handle`.
-  */
-  headers(): Headers;
-  /**
-  * Returns the resource corresponding to the outgoing Body for this Response.
-  * 
-  * Returns success on the first call: the `outgoing-body` resource for
-  * this `outgoing-response` can be retrieved at most once. Subsequent
-  * calls will return error.
-  */
-  body(): OutgoingBody;
-}
-
-export class RequestOptions {
-  /**
-  * Construct a default `request-options` value.
-  */
-  constructor()
-  /**
-  * The timeout for the initial connect to the HTTP Server.
-  */
-  connectTimeout(): Duration | undefined;
-  /**
-  * Set the timeout for the initial connect to the HTTP Server. An error
-  * return value indicates that this timeout is not supported.
-  */
-  setConnectTimeout(duration: Duration | undefined): void;
-  /**
-  * The timeout for receiving the first byte of the Response body.
-  */
-  firstByteTimeout(): Duration | undefined;
-  /**
-  * Set the timeout for receiving the first byte of the Response body. An
-  * error return value indicates that this timeout is not supported.
-  */
-  setFirstByteTimeout(duration: Duration | undefined): void;
-  /**
-  * The timeout for receiving subsequent chunks of bytes in the Response
-  * body stream.
-  */
-  betweenBytesTimeout(): Duration | undefined;
-  /**
-  * Set the timeout for receiving subsequent chunks of bytes in the Response
-  * body stream. An error return value indicates that this timeout is not
-  * supported.
-  */
-  setBetweenBytesTimeout(duration: Duration | undefined): void;
-}
-
-export class ResponseOutparam {
-  /**
-   * This type does not have a public constructor.
+   * These cases are inspired by the IANA HTTP Proxy Error Types:
+   *   <https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types>
    */
-  private constructor();
+  export type ErrorCode = ErrorCodeDnsTimeout | ErrorCodeDnsError | ErrorCodeDestinationNotFound | ErrorCodeDestinationUnavailable | ErrorCodeDestinationIpProhibited | ErrorCodeDestinationIpUnroutable | ErrorCodeConnectionRefused | ErrorCodeConnectionTerminated | ErrorCodeConnectionTimeout | ErrorCodeConnectionReadTimeout | ErrorCodeConnectionWriteTimeout | ErrorCodeConnectionLimitReached | ErrorCodeTlsProtocolError | ErrorCodeTlsCertificateError | ErrorCodeTlsAlertReceived | ErrorCodeHttpRequestDenied | ErrorCodeHttpRequestLengthRequired | ErrorCodeHttpRequestBodySize | ErrorCodeHttpRequestMethodInvalid | ErrorCodeHttpRequestUriInvalid | ErrorCodeHttpRequestUriTooLong | ErrorCodeHttpRequestHeaderSectionSize | ErrorCodeHttpRequestHeaderSize | ErrorCodeHttpRequestTrailerSectionSize | ErrorCodeHttpRequestTrailerSize | ErrorCodeHttpResponseIncomplete | ErrorCodeHttpResponseHeaderSectionSize | ErrorCodeHttpResponseHeaderSize | ErrorCodeHttpResponseBodySize | ErrorCodeHttpResponseTrailerSectionSize | ErrorCodeHttpResponseTrailerSize | ErrorCodeHttpResponseTransferCoding | ErrorCodeHttpResponseContentCoding | ErrorCodeHttpResponseTimeout | ErrorCodeHttpUpgradeFailed | ErrorCodeHttpProtocolError | ErrorCodeLoopDetected | ErrorCodeConfigurationError | ErrorCodeInternalError;
+  export interface ErrorCodeDnsTimeout {
+    tag: 'DNS-timeout',
+  }
+  export interface ErrorCodeDnsError {
+    tag: 'DNS-error',
+    val: DnsErrorPayload,
+  }
+  export interface ErrorCodeDestinationNotFound {
+    tag: 'destination-not-found',
+  }
+  export interface ErrorCodeDestinationUnavailable {
+    tag: 'destination-unavailable',
+  }
+  export interface ErrorCodeDestinationIpProhibited {
+    tag: 'destination-IP-prohibited',
+  }
+  export interface ErrorCodeDestinationIpUnroutable {
+    tag: 'destination-IP-unroutable',
+  }
+  export interface ErrorCodeConnectionRefused {
+    tag: 'connection-refused',
+  }
+  export interface ErrorCodeConnectionTerminated {
+    tag: 'connection-terminated',
+  }
+  export interface ErrorCodeConnectionTimeout {
+    tag: 'connection-timeout',
+  }
+  export interface ErrorCodeConnectionReadTimeout {
+    tag: 'connection-read-timeout',
+  }
+  export interface ErrorCodeConnectionWriteTimeout {
+    tag: 'connection-write-timeout',
+  }
+  export interface ErrorCodeConnectionLimitReached {
+    tag: 'connection-limit-reached',
+  }
+  export interface ErrorCodeTlsProtocolError {
+    tag: 'TLS-protocol-error',
+  }
+  export interface ErrorCodeTlsCertificateError {
+    tag: 'TLS-certificate-error',
+  }
+  export interface ErrorCodeTlsAlertReceived {
+    tag: 'TLS-alert-received',
+    val: TlsAlertReceivedPayload,
+  }
+  export interface ErrorCodeHttpRequestDenied {
+    tag: 'HTTP-request-denied',
+  }
+  export interface ErrorCodeHttpRequestLengthRequired {
+    tag: 'HTTP-request-length-required',
+  }
+  export interface ErrorCodeHttpRequestBodySize {
+    tag: 'HTTP-request-body-size',
+    val: bigint | undefined,
+  }
+  export interface ErrorCodeHttpRequestMethodInvalid {
+    tag: 'HTTP-request-method-invalid',
+  }
+  export interface ErrorCodeHttpRequestUriInvalid {
+    tag: 'HTTP-request-URI-invalid',
+  }
+  export interface ErrorCodeHttpRequestUriTooLong {
+    tag: 'HTTP-request-URI-too-long',
+  }
+  export interface ErrorCodeHttpRequestHeaderSectionSize {
+    tag: 'HTTP-request-header-section-size',
+    val: number | undefined,
+  }
+  export interface ErrorCodeHttpRequestHeaderSize {
+    tag: 'HTTP-request-header-size',
+    val: FieldSizePayload | undefined,
+  }
+  export interface ErrorCodeHttpRequestTrailerSectionSize {
+    tag: 'HTTP-request-trailer-section-size',
+    val: number | undefined,
+  }
+  export interface ErrorCodeHttpRequestTrailerSize {
+    tag: 'HTTP-request-trailer-size',
+    val: FieldSizePayload,
+  }
+  export interface ErrorCodeHttpResponseIncomplete {
+    tag: 'HTTP-response-incomplete',
+  }
+  export interface ErrorCodeHttpResponseHeaderSectionSize {
+    tag: 'HTTP-response-header-section-size',
+    val: number | undefined,
+  }
+  export interface ErrorCodeHttpResponseHeaderSize {
+    tag: 'HTTP-response-header-size',
+    val: FieldSizePayload,
+  }
+  export interface ErrorCodeHttpResponseBodySize {
+    tag: 'HTTP-response-body-size',
+    val: bigint | undefined,
+  }
+  export interface ErrorCodeHttpResponseTrailerSectionSize {
+    tag: 'HTTP-response-trailer-section-size',
+    val: number | undefined,
+  }
+  export interface ErrorCodeHttpResponseTrailerSize {
+    tag: 'HTTP-response-trailer-size',
+    val: FieldSizePayload,
+  }
+  export interface ErrorCodeHttpResponseTransferCoding {
+    tag: 'HTTP-response-transfer-coding',
+    val: string | undefined,
+  }
+  export interface ErrorCodeHttpResponseContentCoding {
+    tag: 'HTTP-response-content-coding',
+    val: string | undefined,
+  }
+  export interface ErrorCodeHttpResponseTimeout {
+    tag: 'HTTP-response-timeout',
+  }
+  export interface ErrorCodeHttpUpgradeFailed {
+    tag: 'HTTP-upgrade-failed',
+  }
+  export interface ErrorCodeHttpProtocolError {
+    tag: 'HTTP-protocol-error',
+  }
+  export interface ErrorCodeLoopDetected {
+    tag: 'loop-detected',
+  }
+  export interface ErrorCodeConfigurationError {
+    tag: 'configuration-error',
+  }
   /**
-  * Set the value of the `response-outparam` to either send a response,
-  * or indicate an error.
-  * 
-  * This method consumes the `response-outparam` to ensure that it is
-  * called at most once. If it is never called, the implementation
-  * will respond with an error.
-  * 
-  * The user may provide an `error` to `response` to allow the
-  * implementation determine how to respond with an HTTP error response.
-  */
-  static set(param: ResponseOutparam, response: Result<OutgoingResponse, ErrorCode>): void;
+   * This is a catch-all error for anything that doesn't fit cleanly into a
+   * more specific case. It also includes an optional string for an
+   * unstructured description of the error. Users should not depend on the
+   * string for diagnosing errors, as it's not required to be consistent
+   * between implementations.
+   */
+  export interface ErrorCodeInternalError {
+    tag: 'internal-error',
+    val: string | undefined,
+  }
+  /**
+   * This type enumerates the different kinds of errors that may occur when
+   * setting or appending to a `fields` resource.
+   */
+  export type HeaderError = HeaderErrorInvalidSyntax | HeaderErrorForbidden | HeaderErrorImmutable;
+  /**
+   * This error indicates that a `field-name` or `field-value` was
+   * syntactically invalid when used with an operation that sets headers in a
+   * `fields`.
+   */
+  export interface HeaderErrorInvalidSyntax {
+    tag: 'invalid-syntax',
+  }
+  /**
+   * This error indicates that a forbidden `field-name` was used when trying
+   * to set a header in a `fields`.
+   */
+  export interface HeaderErrorForbidden {
+    tag: 'forbidden',
+  }
+  /**
+   * This error indicates that the operation on the `fields` was not
+   * permitted because the fields are immutable.
+   */
+  export interface HeaderErrorImmutable {
+    tag: 'immutable',
+  }
+  /**
+   * Field keys are always strings.
+   * 
+   * Field keys should always be treated as case insensitive by the `fields`
+   * resource for the purposes of equality checking.
+   * 
+   * # Deprecation
+   * 
+   * This type has been deprecated in favor of the `field-name` type.
+   */
+  export type FieldKey = string;
+  /**
+   * Field names are always strings.
+   * 
+   * Field names should always be treated as case insensitive by the `fields`
+   * resource for the purposes of equality checking.
+   */
+  export type FieldName = FieldKey;
+  /**
+   * Field values should always be ASCII strings. However, in
+   * reality, HTTP implementations often have to interpret malformed values,
+   * so they are provided as a list of bytes.
+   */
+  export type FieldValue = Uint8Array;
+  /**
+   * Headers is an alias for Fields.
+   */
+  export type Headers = Fields;
+  /**
+   * Trailers is an alias for Fields.
+   */
+  export type Trailers = Fields;
+  /**
+   * This type corresponds to the HTTP standard Status Code.
+   */
+  export type StatusCode = number;
+  export type Result<T, E> = { tag: 'ok', val: T } | { tag: 'err', val: E };
+  
+  export class Fields implements Disposable {
+    /**
+    * Construct an empty HTTP Fields.
+    * 
+    * The resulting `fields` is mutable.
+    */
+    constructor()
+    /**
+    * Construct an HTTP Fields.
+    * 
+    * The resulting `fields` is mutable.
+    * 
+    * The list represents each name-value pair in the Fields. Names
+    * which have multiple values are represented by multiple entries in this
+    * list with the same name.
+    * 
+    * The tuple is a pair of the field name, represented as a string, and
+    * Value, represented as a list of bytes.
+    * 
+    * An error result will be returned if any `field-name` or `field-value` is
+    * syntactically invalid, or if a field is forbidden.
+    */
+    static fromList(entries: Array<[FieldName, FieldValue]>): Fields;
+    /**
+    * Get all of the values corresponding to a name. If the name is not present
+    * in this `fields` or is syntactically invalid, an empty list is returned.
+    * However, if the name is present but empty, this is represented by a list
+    * with one or more empty field-values present.
+    */
+    get(name: FieldName): Array<FieldValue>;
+    /**
+    * Returns `true` when the name is present in this `fields`. If the name is
+    * syntactically invalid, `false` is returned.
+    */
+    has(name: FieldName): boolean;
+    /**
+    * Set all of the values for a name. Clears any existing values for that
+    * name, if they have been set.
+    * 
+    * Fails with `header-error.immutable` if the `fields` are immutable.
+    * 
+    * Fails with `header-error.invalid-syntax` if the `field-name` or any of
+    * the `field-value`s are syntactically invalid.
+    */
+    set(name: FieldName, value: Array<FieldValue>): void;
+    /**
+    * Delete all values for a name. Does nothing if no values for the name
+    * exist.
+    * 
+    * Fails with `header-error.immutable` if the `fields` are immutable.
+    * 
+    * Fails with `header-error.invalid-syntax` if the `field-name` is
+    * syntactically invalid.
+    */
+    'delete'(name: FieldName): void;
+    /**
+    * Append a value for a name. Does not change or delete any existing
+    * values for that name.
+    * 
+    * Fails with `header-error.immutable` if the `fields` are immutable.
+    * 
+    * Fails with `header-error.invalid-syntax` if the `field-name` or
+    * `field-value` are syntactically invalid.
+    */
+    append(name: FieldName, value: FieldValue): void;
+    /**
+    * Retrieve the full set of names and values in the Fields. Like the
+    * constructor, the list represents each name-value pair.
+    * 
+    * The outer list represents each name-value pair in the Fields. Names
+    * which have multiple values are represented by multiple entries in this
+    * list with the same name.
+    * 
+    * The names and values are always returned in the original casing and in
+    * the order in which they will be serialized for transport.
+    */
+    entries(): Array<[FieldName, FieldValue]>;
+    /**
+    * Make a deep copy of the Fields. Equivalent in behavior to calling the
+    * `fields` constructor on the return value of `entries`. The resulting
+    * `fields` is mutable.
+    */
+    clone(): Fields;
+    [Symbol.dispose](): void;
+  }
+  
+  export class FutureIncomingResponse implements Disposable {
+    /**
+     * This type does not have a public constructor.
+     */
+    private constructor();
+    /**
+    * Returns a pollable which becomes ready when either the Response has
+    * been received, or an error has occurred. When this pollable is ready,
+    * the `get` method will return `some`.
+    */
+    subscribe(): Pollable;
+    /**
+    * Returns the incoming HTTP Response, or an error, once one is ready.
+    * 
+    * The outer `option` represents future readiness. Users can wait on this
+    * `option` to become `some` using the `subscribe` method.
+    * 
+    * The outer `result` is used to retrieve the response or error at most
+    * once. It will be success on the first call in which the outer option
+    * is `some`, and error on subsequent calls.
+    * 
+    * The inner `result` represents that either the incoming HTTP Response
+    * status and headers have received successfully, or that an error
+    * occurred. Errors may also occur while consuming the response body,
+    * but those will be reported by the `incoming-body` and its
+    * `output-stream` child.
+    */
+    get(): Result<Result<IncomingResponse, ErrorCode>, void> | undefined;
+    [Symbol.dispose](): void;
+  }
+  
+  export class FutureTrailers implements Disposable {
+    /**
+     * This type does not have a public constructor.
+     */
+    private constructor();
+    /**
+    * Returns a pollable which becomes ready when either the trailers have
+    * been received, or an error has occurred. When this pollable is ready,
+    * the `get` method will return `some`.
+    */
+    subscribe(): Pollable;
+    /**
+    * Returns the contents of the trailers, or an error which occurred,
+    * once the future is ready.
+    * 
+    * The outer `option` represents future readiness. Users can wait on this
+    * `option` to become `some` using the `subscribe` method.
+    * 
+    * The outer `result` is used to retrieve the trailers or error at most
+    * once. It will be success on the first call in which the outer option
+    * is `some`, and error on subsequent calls.
+    * 
+    * The inner `result` represents that either the HTTP Request or Response
+    * body, as well as any trailers, were received successfully, or that an
+    * error occurred receiving them. The optional `trailers` indicates whether
+    * or not trailers were present in the body.
+    * 
+    * When some `trailers` are returned by this method, the `trailers`
+    * resource is immutable, and a child. Use of the `set`, `append`, or
+    * `delete` methods will return an error, and the resource must be
+    * dropped before the parent `future-trailers` is dropped.
+    */
+    get(): Result<Result<Trailers | undefined, ErrorCode>, void> | undefined;
+    [Symbol.dispose](): void;
+  }
+  
+  export class IncomingBody implements Disposable {
+    /**
+     * This type does not have a public constructor.
+     */
+    private constructor();
+    /**
+    * Returns the contents of the body, as a stream of bytes.
+    * 
+    * Returns success on first call: the stream representing the contents
+    * can be retrieved at most once. Subsequent calls will return error.
+    * 
+    * The returned `input-stream` resource is a child: it must be dropped
+    * before the parent `incoming-body` is dropped, or consumed by
+    * `incoming-body.finish`.
+    * 
+    * This invariant ensures that the implementation can determine whether
+    * the user is consuming the contents of the body, waiting on the
+    * `future-trailers` to be ready, or neither. This allows for network
+    * backpressure is to be applied when the user is consuming the body,
+    * and for that backpressure to not inhibit delivery of the trailers if
+    * the user does not read the entire body.
+    */
+    stream(): InputStream;
+    /**
+    * Takes ownership of `incoming-body`, and returns a `future-trailers`.
+    * This function will trap if the `input-stream` child is still alive.
+    */
+    static finish(this_: IncomingBody): FutureTrailers;
+    [Symbol.dispose](): void;
+  }
+  
+  export class IncomingRequest implements Disposable {
+    /**
+     * This type does not have a public constructor.
+     */
+    private constructor();
+    /**
+    * Returns the method of the incoming request.
+    */
+    method(): Method;
+    /**
+    * Returns the path with query parameters from the request, as a string.
+    */
+    pathWithQuery(): string | undefined;
+    /**
+    * Returns the protocol scheme from the request.
+    */
+    scheme(): Scheme | undefined;
+    /**
+    * Returns the authority of the Request's target URI, if present.
+    */
+    authority(): string | undefined;
+    /**
+    * Get the `headers` associated with the request.
+    * 
+    * The returned `headers` resource is immutable: `set`, `append`, and
+    * `delete` operations will fail with `header-error.immutable`.
+    * 
+    * The `headers` returned are a child resource: it must be dropped before
+    * the parent `incoming-request` is dropped. Dropping this
+    * `incoming-request` before all children are dropped will trap.
+    */
+    headers(): Headers;
+    /**
+    * Gives the `incoming-body` associated with this request. Will only
+    * return success at most once, and subsequent calls will return error.
+    */
+    consume(): IncomingBody;
+    [Symbol.dispose](): void;
+  }
+  
+  export class IncomingResponse implements Disposable {
+    /**
+     * This type does not have a public constructor.
+     */
+    private constructor();
+    /**
+    * Returns the status code from the incoming response.
+    */
+    status(): StatusCode;
+    /**
+    * Returns the headers from the incoming response.
+    * 
+    * The returned `headers` resource is immutable: `set`, `append`, and
+    * `delete` operations will fail with `header-error.immutable`.
+    * 
+    * This headers resource is a child: it must be dropped before the parent
+    * `incoming-response` is dropped.
+    */
+    headers(): Headers;
+    /**
+    * Returns the incoming body. May be called at most once. Returns error
+    * if called additional times.
+    */
+    consume(): IncomingBody;
+    [Symbol.dispose](): void;
+  }
+  
+  export class OutgoingBody implements Disposable {
+    /**
+     * This type does not have a public constructor.
+     */
+    private constructor();
+    /**
+    * Returns a stream for writing the body contents.
+    * 
+    * The returned `output-stream` is a child resource: it must be dropped
+    * before the parent `outgoing-body` resource is dropped (or finished),
+    * otherwise the `outgoing-body` drop or `finish` will trap.
+    * 
+    * Returns success on the first call: the `output-stream` resource for
+    * this `outgoing-body` may be retrieved at most once. Subsequent calls
+    * will return error.
+    */
+    write(): OutputStream;
+    /**
+    * Finalize an outgoing body, optionally providing trailers. This must be
+    * called to signal that the response is complete. If the `outgoing-body`
+    * is dropped without calling `outgoing-body.finalize`, the implementation
+    * should treat the body as corrupted.
+    * 
+    * Fails if the body's `outgoing-request` or `outgoing-response` was
+    * constructed with a Content-Length header, and the contents written
+    * to the body (via `write`) does not match the value given in the
+    * Content-Length.
+    */
+    static finish(this_: OutgoingBody, trailers: Trailers | undefined): void;
+    [Symbol.dispose](): void;
+  }
+  
+  export class OutgoingRequest implements Disposable {
+    /**
+    * Construct a new `outgoing-request` with a default `method` of `GET`, and
+    * `none` values for `path-with-query`, `scheme`, and `authority`.
+    * 
+    * * `headers` is the HTTP Headers for the Request.
+    * 
+    * It is possible to construct, or manipulate with the accessor functions
+    * below, an `outgoing-request` with an invalid combination of `scheme`
+    * and `authority`, or `headers` which are not permitted to be sent.
+    * It is the obligation of the `outgoing-handler.handle` implementation
+    * to reject invalid constructions of `outgoing-request`.
+    */
+    constructor(headers: Headers)
+    /**
+    * Returns the resource corresponding to the outgoing Body for this
+    * Request.
+    * 
+    * Returns success on the first call: the `outgoing-body` resource for
+    * this `outgoing-request` can be retrieved at most once. Subsequent
+    * calls will return error.
+    */
+    body(): OutgoingBody;
+    /**
+    * Get the Method for the Request.
+    */
+    method(): Method;
+    /**
+    * Set the Method for the Request. Fails if the string present in a
+    * `method.other` argument is not a syntactically valid method.
+    */
+    setMethod(method: Method): void;
+    /**
+    * Get the combination of the HTTP Path and Query for the Request.
+    * When `none`, this represents an empty Path and empty Query.
+    */
+    pathWithQuery(): string | undefined;
+    /**
+    * Set the combination of the HTTP Path and Query for the Request.
+    * When `none`, this represents an empty Path and empty Query. Fails is the
+    * string given is not a syntactically valid path and query uri component.
+    */
+    setPathWithQuery(pathWithQuery: string | undefined): void;
+    /**
+    * Get the HTTP Related Scheme for the Request. When `none`, the
+    * implementation may choose an appropriate default scheme.
+    */
+    scheme(): Scheme | undefined;
+    /**
+    * Set the HTTP Related Scheme for the Request. When `none`, the
+    * implementation may choose an appropriate default scheme. Fails if the
+    * string given is not a syntactically valid uri scheme.
+    */
+    setScheme(scheme: Scheme | undefined): void;
+    /**
+    * Get the authority of the Request's target URI. A value of `none` may be used
+    * with Related Schemes which do not require an authority. The HTTP and
+    * HTTPS schemes always require an authority.
+    */
+    authority(): string | undefined;
+    /**
+    * Set the authority of the Request's target URI. A value of `none` may be used
+    * with Related Schemes which do not require an authority. The HTTP and
+    * HTTPS schemes always require an authority. Fails if the string given is
+    * not a syntactically valid URI authority.
+    */
+    setAuthority(authority: string | undefined): void;
+    /**
+    * Get the headers associated with the Request.
+    * 
+    * The returned `headers` resource is immutable: `set`, `append`, and
+    * `delete` operations will fail with `header-error.immutable`.
+    * 
+    * This headers resource is a child: it must be dropped before the parent
+    * `outgoing-request` is dropped, or its ownership is transferred to
+    * another component by e.g. `outgoing-handler.handle`.
+    */
+    headers(): Headers;
+    [Symbol.dispose](): void;
+  }
+  
+  export class OutgoingResponse implements Disposable {
+    /**
+    * Construct an `outgoing-response`, with a default `status-code` of `200`.
+    * If a different `status-code` is needed, it must be set via the
+    * `set-status-code` method.
+    * 
+    * * `headers` is the HTTP Headers for the Response.
+    */
+    constructor(headers: Headers)
+    /**
+    * Get the HTTP Status Code for the Response.
+    */
+    statusCode(): StatusCode;
+    /**
+    * Set the HTTP Status Code for the Response. Fails if the status-code
+    * given is not a valid http status code.
+    */
+    setStatusCode(statusCode: StatusCode): void;
+    /**
+    * Get the headers associated with the Request.
+    * 
+    * The returned `headers` resource is immutable: `set`, `append`, and
+    * `delete` operations will fail with `header-error.immutable`.
+    * 
+    * This headers resource is a child: it must be dropped before the parent
+    * `outgoing-request` is dropped, or its ownership is transferred to
+    * another component by e.g. `outgoing-handler.handle`.
+    */
+    headers(): Headers;
+    /**
+    * Returns the resource corresponding to the outgoing Body for this Response.
+    * 
+    * Returns success on the first call: the `outgoing-body` resource for
+    * this `outgoing-response` can be retrieved at most once. Subsequent
+    * calls will return error.
+    */
+    body(): OutgoingBody;
+    [Symbol.dispose](): void;
+  }
+  
+  export class RequestOptions implements Disposable {
+    /**
+    * Construct a default `request-options` value.
+    */
+    constructor()
+    /**
+    * The timeout for the initial connect to the HTTP Server.
+    */
+    connectTimeout(): Duration | undefined;
+    /**
+    * Set the timeout for the initial connect to the HTTP Server. An error
+    * return value indicates that this timeout is not supported.
+    */
+    setConnectTimeout(duration: Duration | undefined): void;
+    /**
+    * The timeout for receiving the first byte of the Response body.
+    */
+    firstByteTimeout(): Duration | undefined;
+    /**
+    * Set the timeout for receiving the first byte of the Response body. An
+    * error return value indicates that this timeout is not supported.
+    */
+    setFirstByteTimeout(duration: Duration | undefined): void;
+    /**
+    * The timeout for receiving subsequent chunks of bytes in the Response
+    * body stream.
+    */
+    betweenBytesTimeout(): Duration | undefined;
+    /**
+    * Set the timeout for receiving subsequent chunks of bytes in the Response
+    * body stream. An error return value indicates that this timeout is not
+    * supported.
+    */
+    setBetweenBytesTimeout(duration: Duration | undefined): void;
+    [Symbol.dispose](): void;
+  }
+  
+  export class ResponseOutparam implements Disposable {
+    /**
+     * This type does not have a public constructor.
+     */
+    private constructor();
+    /**
+    * Set the value of the `response-outparam` to either send a response,
+    * or indicate an error.
+    * 
+    * This method consumes the `response-outparam` to ensure that it is
+    * called at most once. If it is never called, the implementation
+    * will respond with an error.
+    * 
+    * The user may provide an `error` to `response` to allow the
+    * implementation determine how to respond with an HTTP error response.
+    */
+    static set(param: ResponseOutparam, response: Result<OutgoingResponse, ErrorCode>): void;
+    [Symbol.dispose](): void;
+  }
 }

--- a/templates/service-tcp-echo/component/generated/types/interfaces/wasi-io-error.d.ts
+++ b/templates/service-tcp-echo/component/generated/types/interfaces/wasi-io-error.d.ts
@@ -1,9 +1,11 @@
-/** @module Interface wasi:io/error@0.2.3 **/
-
-export class Error {
-  /**
-   * This type does not have a public constructor.
-   */
-  private constructor();
-  toDebugString(): string;
+declare module 'wasi:io/error@0.2.3' {
+  
+  export class Error implements Disposable {
+    /**
+     * This type does not have a public constructor.
+     */
+    private constructor();
+    toDebugString(): string;
+    [Symbol.dispose](): void;
+  }
 }

--- a/templates/service-tcp-echo/component/generated/types/interfaces/wasi-io-poll.d.ts
+++ b/templates/service-tcp-echo/component/generated/types/interfaces/wasi-io-poll.d.ts
@@ -1,43 +1,45 @@
-/** @module Interface wasi:io/poll@0.2.0 **/
-/**
- * Poll for completion on a set of pollables.
- * 
- * This function takes a list of pollables, which identify I/O sources of
- * interest, and waits until one or more of the events is ready for I/O.
- * 
- * The result `list<u32>` contains one or more indices of handles in the
- * argument list that is ready for I/O.
- * 
- * If the list contains more elements than can be indexed with a `u32`
- * value, this function traps.
- * 
- * A timeout can be implemented by adding a pollable from the
- * wasi-clocks API to the list.
- * 
- * This function does not return a `result`; polling in itself does not
- * do any I/O so it doesn't fail. If any of the I/O sources identified by
- * the pollables has an error, it is indicated by marking the source as
- * being reaedy for I/O.
- */
-export function poll(in_: Array<Pollable>): Uint32Array;
-
-export class Pollable {
+declare module 'wasi:io/poll@0.2.0' {
   /**
-   * This type does not have a public constructor.
+   * Poll for completion on a set of pollables.
+   * 
+   * This function takes a list of pollables, which identify I/O sources of
+   * interest, and waits until one or more of the events is ready for I/O.
+   * 
+   * The result `list<u32>` contains one or more indices of handles in the
+   * argument list that is ready for I/O.
+   * 
+   * If the list contains more elements than can be indexed with a `u32`
+   * value, this function traps.
+   * 
+   * A timeout can be implemented by adding a pollable from the
+   * wasi-clocks API to the list.
+   * 
+   * This function does not return a `result`; polling in itself does not
+   * do any I/O so it doesn't fail. If any of the I/O sources identified by
+   * the pollables has an error, it is indicated by marking the source as
+   * being reaedy for I/O.
    */
-  private constructor();
-  /**
-  * Return the readiness of a pollable. This function never blocks.
-  * 
-  * Returns `true` when the pollable is ready, and `false` otherwise.
-  */
-  ready(): boolean;
-  /**
-  * `block` returns immediately if the pollable is ready, and otherwise
-  * blocks until ready.
-  * 
-  * This function is equivalent to calling `poll.poll` on a list
-  * containing only this pollable.
-  */
-  block(): void;
+  export function poll(in_: Array<Pollable>): Uint32Array;
+  
+  export class Pollable implements Disposable {
+    /**
+     * This type does not have a public constructor.
+     */
+    private constructor();
+    /**
+    * Return the readiness of a pollable. This function never blocks.
+    * 
+    * Returns `true` when the pollable is ready, and `false` otherwise.
+    */
+    ready(): boolean;
+    /**
+    * `block` returns immediately if the pollable is ready, and otherwise
+    * blocks until ready.
+    * 
+    * This function is equivalent to calling `poll.poll` on a list
+    * containing only this pollable.
+    */
+    block(): void;
+    [Symbol.dispose](): void;
+  }
 }

--- a/templates/service-tcp-echo/component/generated/types/interfaces/wasi-io-streams.d.ts
+++ b/templates/service-tcp-echo/component/generated/types/interfaces/wasi-io-streams.d.ts
@@ -1,40 +1,45 @@
-/** @module Interface wasi:io/streams@0.2.3 **/
-export type Error = import('./wasi-io-error.js').Error;
-export type Pollable = import('./wasi-io-poll.js').Pollable;
-export type StreamError = StreamErrorLastOperationFailed | StreamErrorClosed;
-export interface StreamErrorLastOperationFailed {
-  tag: 'last-operation-failed',
-  val: Error,
-}
-export interface StreamErrorClosed {
-  tag: 'closed',
-}
-
-export class InputStream {
-  /**
-   * This type does not have a public constructor.
-   */
-  private constructor();
-  read(len: bigint): Uint8Array;
-  blockingRead(len: bigint): Uint8Array;
-  skip(len: bigint): bigint;
-  blockingSkip(len: bigint): bigint;
-  subscribe(): Pollable;
-}
-
-export class OutputStream {
-  /**
-   * This type does not have a public constructor.
-   */
-  private constructor();
-  checkWrite(): bigint;
-  write(contents: Uint8Array): void;
-  blockingWriteAndFlush(contents: Uint8Array): void;
-  flush(): void;
-  blockingFlush(): void;
-  subscribe(): Pollable;
-  writeZeroes(len: bigint): void;
-  blockingWriteZeroesAndFlush(len: bigint): void;
-  splice(src: InputStream, len: bigint): bigint;
-  blockingSplice(src: InputStream, len: bigint): bigint;
+/// <reference path="./wasi-io-error.d.ts" />
+/// <reference path="./wasi-io-poll.d.ts" />
+declare module 'wasi:io/streams@0.2.3' {
+  export type Error = import('wasi:io/error@0.2.3').Error;
+  export type Pollable = import('wasi:io/poll@0.2.3').Pollable;
+  export type StreamError = StreamErrorLastOperationFailed | StreamErrorClosed;
+  export interface StreamErrorLastOperationFailed {
+    tag: 'last-operation-failed',
+    val: Error,
+  }
+  export interface StreamErrorClosed {
+    tag: 'closed',
+  }
+  
+  export class InputStream implements Disposable {
+    /**
+     * This type does not have a public constructor.
+     */
+    private constructor();
+    read(len: bigint): Uint8Array;
+    blockingRead(len: bigint): Uint8Array;
+    skip(len: bigint): bigint;
+    blockingSkip(len: bigint): bigint;
+    subscribe(): Pollable;
+    [Symbol.dispose](): void;
+  }
+  
+  export class OutputStream implements Disposable {
+    /**
+     * This type does not have a public constructor.
+     */
+    private constructor();
+    checkWrite(): bigint;
+    write(contents: Uint8Array): void;
+    blockingWriteAndFlush(contents: Uint8Array): void;
+    flush(): void;
+    blockingFlush(): void;
+    subscribe(): Pollable;
+    writeZeroes(len: bigint): void;
+    blockingWriteZeroesAndFlush(len: bigint): void;
+    splice(src: InputStream, len: bigint): bigint;
+    blockingSplice(src: InputStream, len: bigint): bigint;
+    [Symbol.dispose](): void;
+  }
 }

--- a/templates/service-tcp-echo/component/generated/types/interfaces/wasi-sockets-instance-network.d.ts
+++ b/templates/service-tcp-echo/component/generated/types/interfaces/wasi-sockets-instance-network.d.ts
@@ -1,6 +1,8 @@
-/** @module Interface wasi:sockets/instance-network@0.2.3 **/
-/**
- * Get a handle to the default network.
- */
-export function instanceNetwork(): Network;
-export type Network = import('./wasi-sockets-network.js').Network;
+/// <reference path="./wasi-sockets-network.d.ts" />
+declare module 'wasi:sockets/instance-network@0.2.3' {
+  /**
+   * Get a handle to the default network.
+   */
+  export function instanceNetwork(): Network;
+  export type Network = import('wasi:sockets/network@0.2.3').Network;
+}

--- a/templates/service-tcp-echo/component/generated/types/interfaces/wasi-sockets-network.d.ts
+++ b/templates/service-tcp-echo/component/generated/types/interfaces/wasi-sockets-network.d.ts
@@ -1,164 +1,166 @@
-/** @module Interface wasi:sockets/network@0.2.3 **/
-/**
- * Error codes.
- * 
- * In theory, every API can return any error code.
- * In practice, API's typically only return the errors documented per API
- * combined with a couple of errors that are always possible:
- * - `unknown`
- * - `access-denied`
- * - `not-supported`
- * - `out-of-memory`
- * - `concurrency-conflict`
- * 
- * See each individual API for what the POSIX equivalents are. They sometimes differ per API.
- * # Variants
- * 
- * ## `"unknown"`
- * 
- * Unknown error
- * ## `"access-denied"`
- * 
- * Access denied.
- * 
- * POSIX equivalent: EACCES, EPERM
- * ## `"not-supported"`
- * 
- * The operation is not supported.
- * 
- * POSIX equivalent: EOPNOTSUPP
- * ## `"invalid-argument"`
- * 
- * One of the arguments is invalid.
- * 
- * POSIX equivalent: EINVAL
- * ## `"out-of-memory"`
- * 
- * Not enough memory to complete the operation.
- * 
- * POSIX equivalent: ENOMEM, ENOBUFS, EAI_MEMORY
- * ## `"timeout"`
- * 
- * The operation timed out before it could finish completely.
- * ## `"concurrency-conflict"`
- * 
- * This operation is incompatible with another asynchronous operation that is already in progress.
- * 
- * POSIX equivalent: EALREADY
- * ## `"not-in-progress"`
- * 
- * Trying to finish an asynchronous operation that:
- * - has not been started yet, or:
- * - was already finished by a previous `finish-*` call.
- * 
- * Note: this is scheduled to be removed when `future`s are natively supported.
- * ## `"would-block"`
- * 
- * The operation has been aborted because it could not be completed immediately.
- * 
- * Note: this is scheduled to be removed when `future`s are natively supported.
- * ## `"invalid-state"`
- * 
- * The operation is not valid in the socket's current state.
- * ## `"new-socket-limit"`
- * 
- * A new socket resource could not be created because of a system limit.
- * ## `"address-not-bindable"`
- * 
- * A bind operation failed because the provided address is not an address that the `network` can bind to.
- * ## `"address-in-use"`
- * 
- * A bind operation failed because the provided address is already in use or because there are no ephemeral ports available.
- * ## `"remote-unreachable"`
- * 
- * The remote address is not reachable
- * ## `"connection-refused"`
- * 
- * The TCP connection was forcefully rejected
- * ## `"connection-reset"`
- * 
- * The TCP connection was reset.
- * ## `"connection-aborted"`
- * 
- * A TCP connection was aborted.
- * ## `"datagram-too-large"`
- * 
- * The size of a datagram sent to a UDP socket exceeded the maximum
- * supported size.
- * ## `"name-unresolvable"`
- * 
- * Name does not exist or has no suitable associated IP addresses.
- * ## `"temporary-resolver-failure"`
- * 
- * A temporary failure in name resolution occurred.
- * ## `"permanent-resolver-failure"`
- * 
- * A permanent failure in name resolution occurred.
- */
-export type ErrorCode = 'unknown' | 'access-denied' | 'not-supported' | 'invalid-argument' | 'out-of-memory' | 'timeout' | 'concurrency-conflict' | 'not-in-progress' | 'would-block' | 'invalid-state' | 'new-socket-limit' | 'address-not-bindable' | 'address-in-use' | 'remote-unreachable' | 'connection-refused' | 'connection-reset' | 'connection-aborted' | 'datagram-too-large' | 'name-unresolvable' | 'temporary-resolver-failure' | 'permanent-resolver-failure';
-/**
- * # Variants
- * 
- * ## `"ipv4"`
- * 
- * Similar to `AF_INET` in POSIX.
- * ## `"ipv6"`
- * 
- * Similar to `AF_INET6` in POSIX.
- */
-export type IpAddressFamily = 'ipv4' | 'ipv6';
-export type Ipv4Address = [number, number, number, number];
-export type Ipv6Address = [number, number, number, number, number, number, number, number];
-export type IpAddress = IpAddressIpv4 | IpAddressIpv6;
-export interface IpAddressIpv4 {
-  tag: 'ipv4',
-  val: Ipv4Address,
-}
-export interface IpAddressIpv6 {
-  tag: 'ipv6',
-  val: Ipv6Address,
-}
-export interface Ipv4SocketAddress {
+declare module 'wasi:sockets/network@0.2.3' {
   /**
-   * sin_port
+   * Error codes.
+   * 
+   * In theory, every API can return any error code.
+   * In practice, API's typically only return the errors documented per API
+   * combined with a couple of errors that are always possible:
+   * - `unknown`
+   * - `access-denied`
+   * - `not-supported`
+   * - `out-of-memory`
+   * - `concurrency-conflict`
+   * 
+   * See each individual API for what the POSIX equivalents are. They sometimes differ per API.
+   * # Variants
+   * 
+   * ## `"unknown"`
+   * 
+   * Unknown error
+   * ## `"access-denied"`
+   * 
+   * Access denied.
+   * 
+   * POSIX equivalent: EACCES, EPERM
+   * ## `"not-supported"`
+   * 
+   * The operation is not supported.
+   * 
+   * POSIX equivalent: EOPNOTSUPP
+   * ## `"invalid-argument"`
+   * 
+   * One of the arguments is invalid.
+   * 
+   * POSIX equivalent: EINVAL
+   * ## `"out-of-memory"`
+   * 
+   * Not enough memory to complete the operation.
+   * 
+   * POSIX equivalent: ENOMEM, ENOBUFS, EAI_MEMORY
+   * ## `"timeout"`
+   * 
+   * The operation timed out before it could finish completely.
+   * ## `"concurrency-conflict"`
+   * 
+   * This operation is incompatible with another asynchronous operation that is already in progress.
+   * 
+   * POSIX equivalent: EALREADY
+   * ## `"not-in-progress"`
+   * 
+   * Trying to finish an asynchronous operation that:
+   * - has not been started yet, or:
+   * - was already finished by a previous `finish-*` call.
+   * 
+   * Note: this is scheduled to be removed when `future`s are natively supported.
+   * ## `"would-block"`
+   * 
+   * The operation has been aborted because it could not be completed immediately.
+   * 
+   * Note: this is scheduled to be removed when `future`s are natively supported.
+   * ## `"invalid-state"`
+   * 
+   * The operation is not valid in the socket's current state.
+   * ## `"new-socket-limit"`
+   * 
+   * A new socket resource could not be created because of a system limit.
+   * ## `"address-not-bindable"`
+   * 
+   * A bind operation failed because the provided address is not an address that the `network` can bind to.
+   * ## `"address-in-use"`
+   * 
+   * A bind operation failed because the provided address is already in use or because there are no ephemeral ports available.
+   * ## `"remote-unreachable"`
+   * 
+   * The remote address is not reachable
+   * ## `"connection-refused"`
+   * 
+   * The TCP connection was forcefully rejected
+   * ## `"connection-reset"`
+   * 
+   * The TCP connection was reset.
+   * ## `"connection-aborted"`
+   * 
+   * A TCP connection was aborted.
+   * ## `"datagram-too-large"`
+   * 
+   * The size of a datagram sent to a UDP socket exceeded the maximum
+   * supported size.
+   * ## `"name-unresolvable"`
+   * 
+   * Name does not exist or has no suitable associated IP addresses.
+   * ## `"temporary-resolver-failure"`
+   * 
+   * A temporary failure in name resolution occurred.
+   * ## `"permanent-resolver-failure"`
+   * 
+   * A permanent failure in name resolution occurred.
    */
-  port: number,
+  export type ErrorCode = 'unknown' | 'access-denied' | 'not-supported' | 'invalid-argument' | 'out-of-memory' | 'timeout' | 'concurrency-conflict' | 'not-in-progress' | 'would-block' | 'invalid-state' | 'new-socket-limit' | 'address-not-bindable' | 'address-in-use' | 'remote-unreachable' | 'connection-refused' | 'connection-reset' | 'connection-aborted' | 'datagram-too-large' | 'name-unresolvable' | 'temporary-resolver-failure' | 'permanent-resolver-failure';
   /**
-   * sin_addr
+   * # Variants
+   * 
+   * ## `"ipv4"`
+   * 
+   * Similar to `AF_INET` in POSIX.
+   * ## `"ipv6"`
+   * 
+   * Similar to `AF_INET6` in POSIX.
    */
-  address: Ipv4Address,
-}
-export interface Ipv6SocketAddress {
-  /**
-   * sin6_port
-   */
-  port: number,
-  /**
-   * sin6_flowinfo
-   */
-  flowInfo: number,
-  /**
-   * sin6_addr
-   */
-  address: Ipv6Address,
-  /**
-   * sin6_scope_id
-   */
-  scopeId: number,
-}
-export type IpSocketAddress = IpSocketAddressIpv4 | IpSocketAddressIpv6;
-export interface IpSocketAddressIpv4 {
-  tag: 'ipv4',
-  val: Ipv4SocketAddress,
-}
-export interface IpSocketAddressIpv6 {
-  tag: 'ipv6',
-  val: Ipv6SocketAddress,
-}
-
-export class Network {
-  /**
-   * This type does not have a public constructor.
-   */
-  private constructor();
+  export type IpAddressFamily = 'ipv4' | 'ipv6';
+  export type Ipv4Address = [number, number, number, number];
+  export type Ipv6Address = [number, number, number, number, number, number, number, number];
+  export type IpAddress = IpAddressIpv4 | IpAddressIpv6;
+  export interface IpAddressIpv4 {
+    tag: 'ipv4',
+    val: Ipv4Address,
+  }
+  export interface IpAddressIpv6 {
+    tag: 'ipv6',
+    val: Ipv6Address,
+  }
+  export interface Ipv4SocketAddress {
+    /**
+     * sin_port
+     */
+    port: number,
+    /**
+     * sin_addr
+     */
+    address: Ipv4Address,
+  }
+  export interface Ipv6SocketAddress {
+    /**
+     * sin6_port
+     */
+    port: number,
+    /**
+     * sin6_flowinfo
+     */
+    flowInfo: number,
+    /**
+     * sin6_addr
+     */
+    address: Ipv6Address,
+    /**
+     * sin6_scope_id
+     */
+    scopeId: number,
+  }
+  export type IpSocketAddress = IpSocketAddressIpv4 | IpSocketAddressIpv6;
+  export interface IpSocketAddressIpv4 {
+    tag: 'ipv4',
+    val: Ipv4SocketAddress,
+  }
+  export interface IpSocketAddressIpv6 {
+    tag: 'ipv6',
+    val: Ipv6SocketAddress,
+  }
+  
+  export class Network implements Disposable {
+    /**
+     * This type does not have a public constructor.
+     */
+    private constructor();
+    [Symbol.dispose](): void;
+  }
 }

--- a/templates/service-tcp-echo/component/generated/types/interfaces/wasi-sockets-tcp-create-socket.d.ts
+++ b/templates/service-tcp-echo/component/generated/types/interfaces/wasi-sockets-tcp-create-socket.d.ts
@@ -1,28 +1,31 @@
-/** @module Interface wasi:sockets/tcp-create-socket@0.2.3 **/
-/**
- * Create a new TCP socket.
- * 
- * Similar to `socket(AF_INET or AF_INET6, SOCK_STREAM, IPPROTO_TCP)` in POSIX.
- * On IPv6 sockets, IPV6_V6ONLY is enabled by default and can't be configured otherwise.
- * 
- * This function does not require a network capability handle. This is considered to be safe because
- * at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`connect`
- * is called, the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
- * 
- * All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
- * 
- * # Typical errors
- * - `not-supported`:     The specified `address-family` is not supported. (EAFNOSUPPORT)
- * - `new-socket-limit`:  The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
- * 
- * # References
- * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
- * - <https://man7.org/linux/man-pages/man2/socket.2.html>
- * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
- * - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
- */
-export function createTcpSocket(addressFamily: IpAddressFamily): TcpSocket;
-export type Network = import('./wasi-sockets-network.js').Network;
-export type ErrorCode = import('./wasi-sockets-network.js').ErrorCode;
-export type IpAddressFamily = import('./wasi-sockets-network.js').IpAddressFamily;
-export type TcpSocket = import('./wasi-sockets-tcp.js').TcpSocket;
+/// <reference path="./wasi-sockets-network.d.ts" />
+/// <reference path="./wasi-sockets-tcp.d.ts" />
+declare module 'wasi:sockets/tcp-create-socket@0.2.3' {
+  /**
+   * Create a new TCP socket.
+   * 
+   * Similar to `socket(AF_INET or AF_INET6, SOCK_STREAM, IPPROTO_TCP)` in POSIX.
+   * On IPv6 sockets, IPV6_V6ONLY is enabled by default and can't be configured otherwise.
+   * 
+   * This function does not require a network capability handle. This is considered to be safe because
+   * at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`connect`
+   * is called, the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
+   * 
+   * All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
+   * 
+   * # Typical errors
+   * - `not-supported`:     The specified `address-family` is not supported. (EAFNOSUPPORT)
+   * - `new-socket-limit`:  The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
+   * 
+   * # References
+   * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
+   * - <https://man7.org/linux/man-pages/man2/socket.2.html>
+   * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
+   * - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
+   */
+  export function createTcpSocket(addressFamily: IpAddressFamily): TcpSocket;
+  export type Network = import('wasi:sockets/network@0.2.3').Network;
+  export type ErrorCode = import('wasi:sockets/network@0.2.3').ErrorCode;
+  export type IpAddressFamily = import('wasi:sockets/network@0.2.3').IpAddressFamily;
+  export type TcpSocket = import('wasi:sockets/tcp@0.2.3').TcpSocket;
+}

--- a/templates/service-tcp-echo/component/generated/types/interfaces/wasi-sockets-tcp.d.ts
+++ b/templates/service-tcp-echo/component/generated/types/interfaces/wasi-sockets-tcp.d.ts
@@ -1,359 +1,365 @@
-/** @module Interface wasi:sockets/tcp@0.2.3 **/
-export type InputStream = import('./wasi-io-streams.js').InputStream;
-export type OutputStream = import('./wasi-io-streams.js').OutputStream;
-export type Pollable = import('./wasi-io-poll.js').Pollable;
-export type Duration = import('./wasi-clocks-monotonic-clock.js').Duration;
-export type Network = import('./wasi-sockets-network.js').Network;
-export type ErrorCode = import('./wasi-sockets-network.js').ErrorCode;
-export type IpSocketAddress = import('./wasi-sockets-network.js').IpSocketAddress;
-export type IpAddressFamily = import('./wasi-sockets-network.js').IpAddressFamily;
-/**
- * # Variants
- * 
- * ## `"receive"`
- * 
- * Similar to `SHUT_RD` in POSIX.
- * ## `"send"`
- * 
- * Similar to `SHUT_WR` in POSIX.
- * ## `"both"`
- * 
- * Similar to `SHUT_RDWR` in POSIX.
- */
-export type ShutdownType = 'receive' | 'send' | 'both';
-
-export class TcpSocket {
+/// <reference path="./wasi-clocks-monotonic-clock.d.ts" />
+/// <reference path="./wasi-io-poll.d.ts" />
+/// <reference path="./wasi-io-streams.d.ts" />
+/// <reference path="./wasi-sockets-network.d.ts" />
+declare module 'wasi:sockets/tcp@0.2.3' {
+  export type InputStream = import('wasi:io/streams@0.2.3').InputStream;
+  export type OutputStream = import('wasi:io/streams@0.2.3').OutputStream;
+  export type Pollable = import('wasi:io/poll@0.2.3').Pollable;
+  export type Duration = import('wasi:clocks/monotonic-clock@0.2.3').Duration;
+  export type Network = import('wasi:sockets/network@0.2.3').Network;
+  export type ErrorCode = import('wasi:sockets/network@0.2.3').ErrorCode;
+  export type IpSocketAddress = import('wasi:sockets/network@0.2.3').IpSocketAddress;
+  export type IpAddressFamily = import('wasi:sockets/network@0.2.3').IpAddressFamily;
   /**
-   * This type does not have a public constructor.
+   * # Variants
+   * 
+   * ## `"receive"`
+   * 
+   * Similar to `SHUT_RD` in POSIX.
+   * ## `"send"`
+   * 
+   * Similar to `SHUT_WR` in POSIX.
+   * ## `"both"`
+   * 
+   * Similar to `SHUT_RDWR` in POSIX.
    */
-  private constructor();
-  /**
-  * Bind the socket to a specific network on the provided IP address and port.
-  * 
-  * If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
-  * network interface(s) to bind to.
-  * If the TCP/UDP port is zero, the socket will be bound to a random free port.
-  * 
-  * Bind can be attempted multiple times on the same socket, even with
-  * different arguments on each iteration. But never concurrently and
-  * only as long as the previous bind failed. Once a bind succeeds, the
-  * binding can't be changed anymore.
-  * 
-  * # Typical errors
-  * - `invalid-argument`:          The `local-address` has the wrong address family. (EAFNOSUPPORT, EFAULT on Windows)
-  * - `invalid-argument`:          `local-address` is not a unicast address. (EINVAL)
-  * - `invalid-argument`:          `local-address` is an IPv4-mapped IPv6 address. (EINVAL)
-  * - `invalid-state`:             The socket is already bound. (EINVAL)
-  * - `address-in-use`:            No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
-  * - `address-in-use`:            Address is already in use. (EADDRINUSE)
-  * - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
-  * - `not-in-progress`:           A `bind` operation is not in progress.
-  * - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
-  * 
-  * # Implementors note
-  * When binding to a non-zero port, this bind operation shouldn't be affected by the TIME_WAIT
-  * state of a recently closed socket on the same local address. In practice this means that the SO_REUSEADDR
-  * socket option should be set implicitly on all platforms, except on Windows where this is the default behavior
-  * and SO_REUSEADDR performs something different entirely.
-  * 
-  * Unlike in POSIX, in WASI the bind operation is async. This enables
-  * interactive WASI hosts to inject permission prompts. Runtimes that
-  * don't want to make use of this ability can simply call the native
-  * `bind` as part of either `start-bind` or `finish-bind`.
-  * 
-  * # References
-  * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
-  * - <https://man7.org/linux/man-pages/man2/bind.2.html>
-  * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
-  * - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
-  */
-  startBind(network: Network, localAddress: IpSocketAddress): void;
-  finishBind(): void;
-  /**
-  * Connect to a remote endpoint.
-  * 
-  * On success:
-  * - the socket is transitioned into the `connected` state.
-  * - a pair of streams is returned that can be used to read & write to the connection
-  * 
-  * After a failed connection attempt, the socket will be in the `closed`
-  * state and the only valid action left is to `drop` the socket. A single
-  * socket can not be used to connect more than once.
-  * 
-  * # Typical errors
-  * - `invalid-argument`:          The `remote-address` has the wrong address family. (EAFNOSUPPORT)
-  * - `invalid-argument`:          `remote-address` is not a unicast address. (EINVAL, ENETUNREACH on Linux, EAFNOSUPPORT on MacOS)
-  * - `invalid-argument`:          `remote-address` is an IPv4-mapped IPv6 address. (EINVAL, EADDRNOTAVAIL on Illumos)
-  * - `invalid-argument`:          The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EADDRNOTAVAIL on Windows)
-  * - `invalid-argument`:          The port in `remote-address` is set to 0. (EADDRNOTAVAIL on Windows)
-  * - `invalid-argument`:          The socket is already attached to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
-  * - `invalid-state`:             The socket is already in the `connected` state. (EISCONN)
-  * - `invalid-state`:             The socket is already in the `listening` state. (EOPNOTSUPP, EINVAL on Windows)
-  * - `timeout`:                   Connection timed out. (ETIMEDOUT)
-  * - `connection-refused`:        The connection was forcefully rejected. (ECONNREFUSED)
-  * - `connection-reset`:          The connection was reset. (ECONNRESET)
-  * - `connection-aborted`:        The connection was aborted. (ECONNABORTED)
-  * - `remote-unreachable`:        The remote address is not reachable. (EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN, ENONET)
-  * - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
-  * - `not-in-progress`:           A connect operation is not in progress.
-  * - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
-  * 
-  * # Implementors note
-  * The POSIX equivalent of `start-connect` is the regular `connect` syscall.
-  * Because all WASI sockets are non-blocking this is expected to return
-  * EINPROGRESS, which should be translated to `ok()` in WASI.
-  * 
-  * The POSIX equivalent of `finish-connect` is a `poll` for event `POLLOUT`
-  * with a timeout of 0 on the socket descriptor. Followed by a check for
-  * the `SO_ERROR` socket option, in case the poll signaled readiness.
-  * 
-  * # References
-  * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
-  * - <https://man7.org/linux/man-pages/man2/connect.2.html>
-  * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
-  * - <https://man.freebsd.org/cgi/man.cgi?connect>
-  */
-  startConnect(network: Network, remoteAddress: IpSocketAddress): void;
-  finishConnect(): [InputStream, OutputStream];
-  /**
-  * Start listening for new connections.
-  * 
-  * Transitions the socket into the `listening` state.
-  * 
-  * Unlike POSIX, the socket must already be explicitly bound.
-  * 
-  * # Typical errors
-  * - `invalid-state`:             The socket is not bound to any local address. (EDESTADDRREQ)
-  * - `invalid-state`:             The socket is already in the `connected` state. (EISCONN, EINVAL on BSD)
-  * - `invalid-state`:             The socket is already in the `listening` state.
-  * - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE)
-  * - `not-in-progress`:           A listen operation is not in progress.
-  * - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
-  * 
-  * # Implementors note
-  * Unlike in POSIX, in WASI the listen operation is async. This enables
-  * interactive WASI hosts to inject permission prompts. Runtimes that
-  * don't want to make use of this ability can simply call the native
-  * `listen` as part of either `start-listen` or `finish-listen`.
-  * 
-  * # References
-  * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html>
-  * - <https://man7.org/linux/man-pages/man2/listen.2.html>
-  * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen>
-  * - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
-  */
-  startListen(): void;
-  finishListen(): void;
-  /**
-  * Accept a new client socket.
-  * 
-  * The returned socket is bound and in the `connected` state. The following properties are inherited from the listener socket:
-  * - `address-family`
-  * - `keep-alive-enabled`
-  * - `keep-alive-idle-time`
-  * - `keep-alive-interval`
-  * - `keep-alive-count`
-  * - `hop-limit`
-  * - `receive-buffer-size`
-  * - `send-buffer-size`
-  * 
-  * On success, this function returns the newly accepted client socket along with
-  * a pair of streams that can be used to read & write to the connection.
-  * 
-  * # Typical errors
-  * - `invalid-state`:      Socket is not in the `listening` state. (EINVAL)
-  * - `would-block`:        No pending connections at the moment. (EWOULDBLOCK, EAGAIN)
-  * - `connection-aborted`: An incoming connection was pending, but was terminated by the client before this listener could accept it. (ECONNABORTED)
-  * - `new-socket-limit`:   The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
-  * 
-  * # References
-  * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html>
-  * - <https://man7.org/linux/man-pages/man2/accept.2.html>
-  * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept>
-  * - <https://man.freebsd.org/cgi/man.cgi?query=accept&sektion=2>
-  */
-  accept(): [TcpSocket, InputStream, OutputStream];
-  /**
-  * Get the bound local address.
-  * 
-  * POSIX mentions:
-  * > If the socket has not been bound to a local name, the value
-  * > stored in the object pointed to by `address` is unspecified.
-  * 
-  * WASI is stricter and requires `local-address` to return `invalid-state` when the socket hasn't been bound yet.
-  * 
-  * # Typical errors
-  * - `invalid-state`: The socket is not bound to any local address.
-  * 
-  * # References
-  * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
-  * - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
-  * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
-  * - <https://man.freebsd.org/cgi/man.cgi?getsockname>
-  */
-  localAddress(): IpSocketAddress;
-  /**
-  * Get the remote address.
-  * 
-  * # Typical errors
-  * - `invalid-state`: The socket is not connected to a remote address. (ENOTCONN)
-  * 
-  * # References
-  * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
-  * - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
-  * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
-  * - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
-  */
-  remoteAddress(): IpSocketAddress;
-  /**
-  * Whether the socket is in the `listening` state.
-  * 
-  * Equivalent to the SO_ACCEPTCONN socket option.
-  */
-  isListening(): boolean;
-  /**
-  * Whether this is a IPv4 or IPv6 socket.
-  * 
-  * Equivalent to the SO_DOMAIN socket option.
-  */
-  addressFamily(): IpAddressFamily;
-  /**
-  * Hints the desired listen queue size. Implementations are free to ignore this.
-  * 
-  * If the provided value is 0, an `invalid-argument` error is returned.
-  * Any other value will never cause an error, but it might be silently clamped and/or rounded.
-  * 
-  * # Typical errors
-  * - `not-supported`:        (set) The platform does not support changing the backlog size after the initial listen.
-  * - `invalid-argument`:     (set) The provided value was 0.
-  * - `invalid-state`:        (set) The socket is in the `connect-in-progress` or `connected` state.
-  */
-  setListenBacklogSize(value: bigint): void;
-  /**
-  * Enables or disables keepalive.
-  * 
-  * The keepalive behavior can be adjusted using:
-  * - `keep-alive-idle-time`
-  * - `keep-alive-interval`
-  * - `keep-alive-count`
-  * These properties can be configured while `keep-alive-enabled` is false, but only come into effect when `keep-alive-enabled` is true.
-  * 
-  * Equivalent to the SO_KEEPALIVE socket option.
-  */
-  keepAliveEnabled(): boolean;
-  setKeepAliveEnabled(value: boolean): void;
-  /**
-  * Amount of time the connection has to be idle before TCP starts sending keepalive packets.
-  * 
-  * If the provided value is 0, an `invalid-argument` error is returned.
-  * Any other value will never cause an error, but it might be silently clamped and/or rounded.
-  * I.e. after setting a value, reading the same setting back may return a different value.
-  * 
-  * Equivalent to the TCP_KEEPIDLE socket option. (TCP_KEEPALIVE on MacOS)
-  * 
-  * # Typical errors
-  * - `invalid-argument`:     (set) The provided value was 0.
-  */
-  keepAliveIdleTime(): Duration;
-  setKeepAliveIdleTime(value: Duration): void;
-  /**
-  * The time between keepalive packets.
-  * 
-  * If the provided value is 0, an `invalid-argument` error is returned.
-  * Any other value will never cause an error, but it might be silently clamped and/or rounded.
-  * I.e. after setting a value, reading the same setting back may return a different value.
-  * 
-  * Equivalent to the TCP_KEEPINTVL socket option.
-  * 
-  * # Typical errors
-  * - `invalid-argument`:     (set) The provided value was 0.
-  */
-  keepAliveInterval(): Duration;
-  setKeepAliveInterval(value: Duration): void;
-  /**
-  * The maximum amount of keepalive packets TCP should send before aborting the connection.
-  * 
-  * If the provided value is 0, an `invalid-argument` error is returned.
-  * Any other value will never cause an error, but it might be silently clamped and/or rounded.
-  * I.e. after setting a value, reading the same setting back may return a different value.
-  * 
-  * Equivalent to the TCP_KEEPCNT socket option.
-  * 
-  * # Typical errors
-  * - `invalid-argument`:     (set) The provided value was 0.
-  */
-  keepAliveCount(): number;
-  setKeepAliveCount(value: number): void;
-  /**
-  * Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
-  * 
-  * If the provided value is 0, an `invalid-argument` error is returned.
-  * 
-  * # Typical errors
-  * - `invalid-argument`:     (set) The TTL value must be 1 or higher.
-  */
-  hopLimit(): number;
-  setHopLimit(value: number): void;
-  /**
-  * The kernel buffer space reserved for sends/receives on this socket.
-  * 
-  * If the provided value is 0, an `invalid-argument` error is returned.
-  * Any other value will never cause an error, but it might be silently clamped and/or rounded.
-  * I.e. after setting a value, reading the same setting back may return a different value.
-  * 
-  * Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
-  * 
-  * # Typical errors
-  * - `invalid-argument`:     (set) The provided value was 0.
-  */
-  receiveBufferSize(): bigint;
-  setReceiveBufferSize(value: bigint): void;
-  sendBufferSize(): bigint;
-  setSendBufferSize(value: bigint): void;
-  /**
-  * Create a `pollable` which can be used to poll for, or block on,
-  * completion of any of the asynchronous operations of this socket.
-  * 
-  * When `finish-bind`, `finish-listen`, `finish-connect` or `accept`
-  * return `error(would-block)`, this pollable can be used to wait for
-  * their success or failure, after which the method can be retried.
-  * 
-  * The pollable is not limited to the async operation that happens to be
-  * in progress at the time of calling `subscribe` (if any). Theoretically,
-  * `subscribe` only has to be called once per socket and can then be
-  * (re)used for the remainder of the socket's lifetime.
-  * 
-  * See <https://github.com/WebAssembly/wasi-sockets/blob/main/TcpSocketOperationalSemantics.md#pollable-readiness>
-  * for more information.
-  * 
-  * Note: this function is here for WASI 0.2 only.
-  * It's planned to be removed when `future` is natively supported in Preview3.
-  */
-  subscribe(): Pollable;
-  /**
-  * Initiate a graceful shutdown.
-  * 
-  * - `receive`: The socket is not expecting to receive any data from
-  * the peer. The `input-stream` associated with this socket will be
-  * closed. Any data still in the receive queue at time of calling
-  * this method will be discarded.
-  * - `send`: The socket has no more data to send to the peer. The `output-stream`
-  * associated with this socket will be closed and a FIN packet will be sent.
-  * - `both`: Same effect as `receive` & `send` combined.
-  * 
-  * This function is idempotent; shutting down a direction more than once
-  * has no effect and returns `ok`.
-  * 
-  * The shutdown function does not close (drop) the socket.
-  * 
-  * # Typical errors
-  * - `invalid-state`: The socket is not in the `connected` state. (ENOTCONN)
-  * 
-  * # References
-  * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html>
-  * - <https://man7.org/linux/man-pages/man2/shutdown.2.html>
-  * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown>
-  * - <https://man.freebsd.org/cgi/man.cgi?query=shutdown&sektion=2>
-  */
-  shutdown(shutdownType: ShutdownType): void;
+  export type ShutdownType = 'receive' | 'send' | 'both';
+  
+  export class TcpSocket implements Disposable {
+    /**
+     * This type does not have a public constructor.
+     */
+    private constructor();
+    /**
+    * Bind the socket to a specific network on the provided IP address and port.
+    * 
+    * If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
+    * network interface(s) to bind to.
+    * If the TCP/UDP port is zero, the socket will be bound to a random free port.
+    * 
+    * Bind can be attempted multiple times on the same socket, even with
+    * different arguments on each iteration. But never concurrently and
+    * only as long as the previous bind failed. Once a bind succeeds, the
+    * binding can't be changed anymore.
+    * 
+    * # Typical errors
+    * - `invalid-argument`:          The `local-address` has the wrong address family. (EAFNOSUPPORT, EFAULT on Windows)
+    * - `invalid-argument`:          `local-address` is not a unicast address. (EINVAL)
+    * - `invalid-argument`:          `local-address` is an IPv4-mapped IPv6 address. (EINVAL)
+    * - `invalid-state`:             The socket is already bound. (EINVAL)
+    * - `address-in-use`:            No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
+    * - `address-in-use`:            Address is already in use. (EADDRINUSE)
+    * - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
+    * - `not-in-progress`:           A `bind` operation is not in progress.
+    * - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+    * 
+    * # Implementors note
+    * When binding to a non-zero port, this bind operation shouldn't be affected by the TIME_WAIT
+    * state of a recently closed socket on the same local address. In practice this means that the SO_REUSEADDR
+    * socket option should be set implicitly on all platforms, except on Windows where this is the default behavior
+    * and SO_REUSEADDR performs something different entirely.
+    * 
+    * Unlike in POSIX, in WASI the bind operation is async. This enables
+    * interactive WASI hosts to inject permission prompts. Runtimes that
+    * don't want to make use of this ability can simply call the native
+    * `bind` as part of either `start-bind` or `finish-bind`.
+    * 
+    * # References
+    * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
+    * - <https://man7.org/linux/man-pages/man2/bind.2.html>
+    * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
+    * - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
+    */
+    startBind(network: Network, localAddress: IpSocketAddress): void;
+    finishBind(): void;
+    /**
+    * Connect to a remote endpoint.
+    * 
+    * On success:
+    * - the socket is transitioned into the `connected` state.
+    * - a pair of streams is returned that can be used to read & write to the connection
+    * 
+    * After a failed connection attempt, the socket will be in the `closed`
+    * state and the only valid action left is to `drop` the socket. A single
+    * socket can not be used to connect more than once.
+    * 
+    * # Typical errors
+    * - `invalid-argument`:          The `remote-address` has the wrong address family. (EAFNOSUPPORT)
+    * - `invalid-argument`:          `remote-address` is not a unicast address. (EINVAL, ENETUNREACH on Linux, EAFNOSUPPORT on MacOS)
+    * - `invalid-argument`:          `remote-address` is an IPv4-mapped IPv6 address. (EINVAL, EADDRNOTAVAIL on Illumos)
+    * - `invalid-argument`:          The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EADDRNOTAVAIL on Windows)
+    * - `invalid-argument`:          The port in `remote-address` is set to 0. (EADDRNOTAVAIL on Windows)
+    * - `invalid-argument`:          The socket is already attached to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
+    * - `invalid-state`:             The socket is already in the `connected` state. (EISCONN)
+    * - `invalid-state`:             The socket is already in the `listening` state. (EOPNOTSUPP, EINVAL on Windows)
+    * - `timeout`:                   Connection timed out. (ETIMEDOUT)
+    * - `connection-refused`:        The connection was forcefully rejected. (ECONNREFUSED)
+    * - `connection-reset`:          The connection was reset. (ECONNRESET)
+    * - `connection-aborted`:        The connection was aborted. (ECONNABORTED)
+    * - `remote-unreachable`:        The remote address is not reachable. (EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN, ENONET)
+    * - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
+    * - `not-in-progress`:           A connect operation is not in progress.
+    * - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+    * 
+    * # Implementors note
+    * The POSIX equivalent of `start-connect` is the regular `connect` syscall.
+    * Because all WASI sockets are non-blocking this is expected to return
+    * EINPROGRESS, which should be translated to `ok()` in WASI.
+    * 
+    * The POSIX equivalent of `finish-connect` is a `poll` for event `POLLOUT`
+    * with a timeout of 0 on the socket descriptor. Followed by a check for
+    * the `SO_ERROR` socket option, in case the poll signaled readiness.
+    * 
+    * # References
+    * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
+    * - <https://man7.org/linux/man-pages/man2/connect.2.html>
+    * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
+    * - <https://man.freebsd.org/cgi/man.cgi?connect>
+    */
+    startConnect(network: Network, remoteAddress: IpSocketAddress): void;
+    finishConnect(): [InputStream, OutputStream];
+    /**
+    * Start listening for new connections.
+    * 
+    * Transitions the socket into the `listening` state.
+    * 
+    * Unlike POSIX, the socket must already be explicitly bound.
+    * 
+    * # Typical errors
+    * - `invalid-state`:             The socket is not bound to any local address. (EDESTADDRREQ)
+    * - `invalid-state`:             The socket is already in the `connected` state. (EISCONN, EINVAL on BSD)
+    * - `invalid-state`:             The socket is already in the `listening` state.
+    * - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE)
+    * - `not-in-progress`:           A listen operation is not in progress.
+    * - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+    * 
+    * # Implementors note
+    * Unlike in POSIX, in WASI the listen operation is async. This enables
+    * interactive WASI hosts to inject permission prompts. Runtimes that
+    * don't want to make use of this ability can simply call the native
+    * `listen` as part of either `start-listen` or `finish-listen`.
+    * 
+    * # References
+    * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html>
+    * - <https://man7.org/linux/man-pages/man2/listen.2.html>
+    * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen>
+    * - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
+    */
+    startListen(): void;
+    finishListen(): void;
+    /**
+    * Accept a new client socket.
+    * 
+    * The returned socket is bound and in the `connected` state. The following properties are inherited from the listener socket:
+    * - `address-family`
+    * - `keep-alive-enabled`
+    * - `keep-alive-idle-time`
+    * - `keep-alive-interval`
+    * - `keep-alive-count`
+    * - `hop-limit`
+    * - `receive-buffer-size`
+    * - `send-buffer-size`
+    * 
+    * On success, this function returns the newly accepted client socket along with
+    * a pair of streams that can be used to read & write to the connection.
+    * 
+    * # Typical errors
+    * - `invalid-state`:      Socket is not in the `listening` state. (EINVAL)
+    * - `would-block`:        No pending connections at the moment. (EWOULDBLOCK, EAGAIN)
+    * - `connection-aborted`: An incoming connection was pending, but was terminated by the client before this listener could accept it. (ECONNABORTED)
+    * - `new-socket-limit`:   The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
+    * 
+    * # References
+    * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html>
+    * - <https://man7.org/linux/man-pages/man2/accept.2.html>
+    * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept>
+    * - <https://man.freebsd.org/cgi/man.cgi?query=accept&sektion=2>
+    */
+    accept(): [TcpSocket, InputStream, OutputStream];
+    /**
+    * Get the bound local address.
+    * 
+    * POSIX mentions:
+    * > If the socket has not been bound to a local name, the value
+    * > stored in the object pointed to by `address` is unspecified.
+    * 
+    * WASI is stricter and requires `local-address` to return `invalid-state` when the socket hasn't been bound yet.
+    * 
+    * # Typical errors
+    * - `invalid-state`: The socket is not bound to any local address.
+    * 
+    * # References
+    * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
+    * - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
+    * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
+    * - <https://man.freebsd.org/cgi/man.cgi?getsockname>
+    */
+    localAddress(): IpSocketAddress;
+    /**
+    * Get the remote address.
+    * 
+    * # Typical errors
+    * - `invalid-state`: The socket is not connected to a remote address. (ENOTCONN)
+    * 
+    * # References
+    * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
+    * - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
+    * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
+    * - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
+    */
+    remoteAddress(): IpSocketAddress;
+    /**
+    * Whether the socket is in the `listening` state.
+    * 
+    * Equivalent to the SO_ACCEPTCONN socket option.
+    */
+    isListening(): boolean;
+    /**
+    * Whether this is a IPv4 or IPv6 socket.
+    * 
+    * Equivalent to the SO_DOMAIN socket option.
+    */
+    addressFamily(): IpAddressFamily;
+    /**
+    * Hints the desired listen queue size. Implementations are free to ignore this.
+    * 
+    * If the provided value is 0, an `invalid-argument` error is returned.
+    * Any other value will never cause an error, but it might be silently clamped and/or rounded.
+    * 
+    * # Typical errors
+    * - `not-supported`:        (set) The platform does not support changing the backlog size after the initial listen.
+    * - `invalid-argument`:     (set) The provided value was 0.
+    * - `invalid-state`:        (set) The socket is in the `connect-in-progress` or `connected` state.
+    */
+    setListenBacklogSize(value: bigint): void;
+    /**
+    * Enables or disables keepalive.
+    * 
+    * The keepalive behavior can be adjusted using:
+    * - `keep-alive-idle-time`
+    * - `keep-alive-interval`
+    * - `keep-alive-count`
+    * These properties can be configured while `keep-alive-enabled` is false, but only come into effect when `keep-alive-enabled` is true.
+    * 
+    * Equivalent to the SO_KEEPALIVE socket option.
+    */
+    keepAliveEnabled(): boolean;
+    setKeepAliveEnabled(value: boolean): void;
+    /**
+    * Amount of time the connection has to be idle before TCP starts sending keepalive packets.
+    * 
+    * If the provided value is 0, an `invalid-argument` error is returned.
+    * Any other value will never cause an error, but it might be silently clamped and/or rounded.
+    * I.e. after setting a value, reading the same setting back may return a different value.
+    * 
+    * Equivalent to the TCP_KEEPIDLE socket option. (TCP_KEEPALIVE on MacOS)
+    * 
+    * # Typical errors
+    * - `invalid-argument`:     (set) The provided value was 0.
+    */
+    keepAliveIdleTime(): Duration;
+    setKeepAliveIdleTime(value: Duration): void;
+    /**
+    * The time between keepalive packets.
+    * 
+    * If the provided value is 0, an `invalid-argument` error is returned.
+    * Any other value will never cause an error, but it might be silently clamped and/or rounded.
+    * I.e. after setting a value, reading the same setting back may return a different value.
+    * 
+    * Equivalent to the TCP_KEEPINTVL socket option.
+    * 
+    * # Typical errors
+    * - `invalid-argument`:     (set) The provided value was 0.
+    */
+    keepAliveInterval(): Duration;
+    setKeepAliveInterval(value: Duration): void;
+    /**
+    * The maximum amount of keepalive packets TCP should send before aborting the connection.
+    * 
+    * If the provided value is 0, an `invalid-argument` error is returned.
+    * Any other value will never cause an error, but it might be silently clamped and/or rounded.
+    * I.e. after setting a value, reading the same setting back may return a different value.
+    * 
+    * Equivalent to the TCP_KEEPCNT socket option.
+    * 
+    * # Typical errors
+    * - `invalid-argument`:     (set) The provided value was 0.
+    */
+    keepAliveCount(): number;
+    setKeepAliveCount(value: number): void;
+    /**
+    * Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
+    * 
+    * If the provided value is 0, an `invalid-argument` error is returned.
+    * 
+    * # Typical errors
+    * - `invalid-argument`:     (set) The TTL value must be 1 or higher.
+    */
+    hopLimit(): number;
+    setHopLimit(value: number): void;
+    /**
+    * The kernel buffer space reserved for sends/receives on this socket.
+    * 
+    * If the provided value is 0, an `invalid-argument` error is returned.
+    * Any other value will never cause an error, but it might be silently clamped and/or rounded.
+    * I.e. after setting a value, reading the same setting back may return a different value.
+    * 
+    * Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
+    * 
+    * # Typical errors
+    * - `invalid-argument`:     (set) The provided value was 0.
+    */
+    receiveBufferSize(): bigint;
+    setReceiveBufferSize(value: bigint): void;
+    sendBufferSize(): bigint;
+    setSendBufferSize(value: bigint): void;
+    /**
+    * Create a `pollable` which can be used to poll for, or block on,
+    * completion of any of the asynchronous operations of this socket.
+    * 
+    * When `finish-bind`, `finish-listen`, `finish-connect` or `accept`
+    * return `error(would-block)`, this pollable can be used to wait for
+    * their success or failure, after which the method can be retried.
+    * 
+    * The pollable is not limited to the async operation that happens to be
+    * in progress at the time of calling `subscribe` (if any). Theoretically,
+    * `subscribe` only has to be called once per socket and can then be
+    * (re)used for the remainder of the socket's lifetime.
+    * 
+    * See <https://github.com/WebAssembly/wasi-sockets/blob/main/TcpSocketOperationalSemantics.md#pollable-readiness>
+    * for more information.
+    * 
+    * Note: this function is here for WASI 0.2 only.
+    * It's planned to be removed when `future` is natively supported in Preview3.
+    */
+    subscribe(): Pollable;
+    /**
+    * Initiate a graceful shutdown.
+    * 
+    * - `receive`: The socket is not expecting to receive any data from
+    * the peer. The `input-stream` associated with this socket will be
+    * closed. Any data still in the receive queue at time of calling
+    * this method will be discarded.
+    * - `send`: The socket has no more data to send to the peer. The `output-stream`
+    * associated with this socket will be closed and a FIN packet will be sent.
+    * - `both`: Same effect as `receive` & `send` combined.
+    * 
+    * This function is idempotent; shutting down a direction more than once
+    * has no effect and returns `ok`.
+    * 
+    * The shutdown function does not close (drop) the socket.
+    * 
+    * # Typical errors
+    * - `invalid-state`: The socket is not in the `connected` state. (ENOTCONN)
+    * 
+    * # References
+    * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html>
+    * - <https://man7.org/linux/man-pages/man2/shutdown.2.html>
+    * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown>
+    * - <https://man.freebsd.org/cgi/man.cgi?query=shutdown&sektion=2>
+    */
+    shutdown(shutdownType: ShutdownType): void;
+    [Symbol.dispose](): void;
+  }
 }

--- a/templates/service-tcp-echo/component/generated/types/wit.d.ts
+++ b/templates/service-tcp-echo/component/generated/types/wit.d.ts
@@ -1,16 +1,27 @@
-// world wasmcloud:templates/typescript-tcp-component@0.1.0
-export type * as WasiClocksMonotonicClock023 from './interfaces/wasi-clocks-monotonic-clock.js'; // import wasi:clocks/monotonic-clock@0.2.3
-export type * as WasiClocksMonotonicClock026 from './interfaces/wasi-clocks-monotonic-clock.js'; // import wasi:clocks/monotonic-clock@0.2.6
-export type * as WasiHttpTypes026 from './interfaces/wasi-http-types.js'; // import wasi:http/types@0.2.6
-export type * as WasiIoError023 from './interfaces/wasi-io-error.js'; // import wasi:io/error@0.2.3
-export type * as WasiIoError026 from './interfaces/wasi-io-error.js'; // import wasi:io/error@0.2.6
-export type * as WasiIoPoll020 from './interfaces/wasi-io-poll.js'; // import wasi:io/poll@0.2.0
-export type * as WasiIoPoll023 from './interfaces/wasi-io-poll.js'; // import wasi:io/poll@0.2.3
-export type * as WasiIoPoll026 from './interfaces/wasi-io-poll.js'; // import wasi:io/poll@0.2.6
-export type * as WasiIoStreams023 from './interfaces/wasi-io-streams.js'; // import wasi:io/streams@0.2.3
-export type * as WasiIoStreams026 from './interfaces/wasi-io-streams.js'; // import wasi:io/streams@0.2.6
-export type * as WasiSocketsInstanceNetwork023 from './interfaces/wasi-sockets-instance-network.js'; // import wasi:sockets/instance-network@0.2.3
-export type * as WasiSocketsNetwork023 from './interfaces/wasi-sockets-network.js'; // import wasi:sockets/network@0.2.3
-export type * as WasiSocketsTcpCreateSocket023 from './interfaces/wasi-sockets-tcp-create-socket.js'; // import wasi:sockets/tcp-create-socket@0.2.3
-export type * as WasiSocketsTcp023 from './interfaces/wasi-sockets-tcp.js'; // import wasi:sockets/tcp@0.2.3
-export * as incomingHandler from './interfaces/wasi-http-incoming-handler.js'; // export wasi:http/incoming-handler@0.2.6
+/// <reference path="./interfaces/wasi-clocks-monotonic-clock.d.ts" />
+/// <reference path="./interfaces/wasi-http-incoming-handler.d.ts" />
+/// <reference path="./interfaces/wasi-http-types.d.ts" />
+/// <reference path="./interfaces/wasi-io-error.d.ts" />
+/// <reference path="./interfaces/wasi-io-poll.d.ts" />
+/// <reference path="./interfaces/wasi-io-streams.d.ts" />
+/// <reference path="./interfaces/wasi-sockets-instance-network.d.ts" />
+/// <reference path="./interfaces/wasi-sockets-network.d.ts" />
+/// <reference path="./interfaces/wasi-sockets-tcp-create-socket.d.ts" />
+/// <reference path="./interfaces/wasi-sockets-tcp.d.ts" />
+declare module 'wasmcloud:templates/typescript-tcp-component@0.1.0' {
+  export type * as WasiClocksMonotonicClock023 from 'wasi:clocks/monotonic-clock@0.2.3'; // import wasi:clocks/monotonic-clock@0.2.3
+  export type * as WasiClocksMonotonicClock026 from 'wasi:clocks/monotonic-clock@0.2.6'; // import wasi:clocks/monotonic-clock@0.2.6
+  export type * as WasiHttpTypes026 from 'wasi:http/types@0.2.6'; // import wasi:http/types@0.2.6
+  export type * as WasiIoError023 from 'wasi:io/error@0.2.3'; // import wasi:io/error@0.2.3
+  export type * as WasiIoError026 from 'wasi:io/error@0.2.6'; // import wasi:io/error@0.2.6
+  export type * as WasiIoPoll020 from 'wasi:io/poll@0.2.0'; // import wasi:io/poll@0.2.0
+  export type * as WasiIoPoll023 from 'wasi:io/poll@0.2.3'; // import wasi:io/poll@0.2.3
+  export type * as WasiIoPoll026 from 'wasi:io/poll@0.2.6'; // import wasi:io/poll@0.2.6
+  export type * as WasiIoStreams023 from 'wasi:io/streams@0.2.3'; // import wasi:io/streams@0.2.3
+  export type * as WasiIoStreams026 from 'wasi:io/streams@0.2.6'; // import wasi:io/streams@0.2.6
+  export type * as WasiSocketsInstanceNetwork023 from 'wasi:sockets/instance-network@0.2.3'; // import wasi:sockets/instance-network@0.2.3
+  export type * as WasiSocketsNetwork023 from 'wasi:sockets/network@0.2.3'; // import wasi:sockets/network@0.2.3
+  export type * as WasiSocketsTcpCreateSocket023 from 'wasi:sockets/tcp-create-socket@0.2.3'; // import wasi:sockets/tcp-create-socket@0.2.3
+  export type * as WasiSocketsTcp023 from 'wasi:sockets/tcp@0.2.3'; // import wasi:sockets/tcp@0.2.3
+  export * as incomingHandler from 'wasi:http/incoming-handler@0.2.6'; // export wasi:http/incoming-handler@0.2.6
+}

--- a/templates/service-tcp-echo/component/src/component.ts
+++ b/templates/service-tcp-echo/component/src/component.ts
@@ -20,9 +20,7 @@
  *   createTcpSocket → startConnect/finishConnect → read reply → write text
  */
 
-// @ts-expect-error — types generated after running npm run setup:wit
 import { instanceNetwork } from 'wasi:sockets/instance-network@0.2.3';
-// @ts-expect-error
 import { createTcpSocket } from 'wasi:sockets/tcp-create-socket@0.2.3';
 
 import { Hono } from 'hono';

--- a/templates/service-tcp-echo/service/generated/types/interfaces/wasi-cli-run.d.ts
+++ b/templates/service-tcp-echo/service/generated/types/interfaces/wasi-cli-run.d.ts
@@ -1,5 +1,6 @@
-/** @module Interface wasi:cli/run@0.2.0 **/
-/**
- * Run the program.
- */
-export function run(): void;
+declare module 'wasi:cli/run@0.2.0' {
+  /**
+   * Run the program.
+   */
+  export function run(): void;
+}

--- a/templates/service-tcp-echo/service/generated/types/interfaces/wasi-clocks-monotonic-clock.d.ts
+++ b/templates/service-tcp-echo/service/generated/types/interfaces/wasi-clocks-monotonic-clock.d.ts
@@ -1,8 +1,10 @@
-/** @module Interface wasi:clocks/monotonic-clock@0.2.3 **/
-export function now(): Instant;
-export function resolution(): Duration;
-export function subscribeInstant(when: Instant): Pollable;
-export function subscribeDuration(when: Duration): Pollable;
-export type Pollable = import('./wasi-io-poll.js').Pollable;
-export type Instant = bigint;
-export type Duration = bigint;
+/// <reference path="./wasi-io-poll.d.ts" />
+declare module 'wasi:clocks/monotonic-clock@0.2.3' {
+  export function now(): Instant;
+  export function resolution(): Duration;
+  export function subscribeInstant(when: Instant): Pollable;
+  export function subscribeDuration(when: Duration): Pollable;
+  export type Pollable = import('wasi:io/poll@0.2.3').Pollable;
+  export type Instant = bigint;
+  export type Duration = bigint;
+}

--- a/templates/service-tcp-echo/service/generated/types/interfaces/wasi-io-error.d.ts
+++ b/templates/service-tcp-echo/service/generated/types/interfaces/wasi-io-error.d.ts
@@ -1,9 +1,11 @@
-/** @module Interface wasi:io/error@0.2.3 **/
-
-export class Error {
-  /**
-   * This type does not have a public constructor.
-   */
-  private constructor();
-  toDebugString(): string;
+declare module 'wasi:io/error@0.2.3' {
+  
+  export class Error implements Disposable {
+    /**
+     * This type does not have a public constructor.
+     */
+    private constructor();
+    toDebugString(): string;
+    [Symbol.dispose](): void;
+  }
 }

--- a/templates/service-tcp-echo/service/generated/types/interfaces/wasi-io-poll.d.ts
+++ b/templates/service-tcp-echo/service/generated/types/interfaces/wasi-io-poll.d.ts
@@ -1,43 +1,45 @@
-/** @module Interface wasi:io/poll@0.2.0 **/
-/**
- * Poll for completion on a set of pollables.
- * 
- * This function takes a list of pollables, which identify I/O sources of
- * interest, and waits until one or more of the events is ready for I/O.
- * 
- * The result `list<u32>` contains one or more indices of handles in the
- * argument list that is ready for I/O.
- * 
- * If the list contains more elements than can be indexed with a `u32`
- * value, this function traps.
- * 
- * A timeout can be implemented by adding a pollable from the
- * wasi-clocks API to the list.
- * 
- * This function does not return a `result`; polling in itself does not
- * do any I/O so it doesn't fail. If any of the I/O sources identified by
- * the pollables has an error, it is indicated by marking the source as
- * being reaedy for I/O.
- */
-export function poll(in_: Array<Pollable>): Uint32Array;
-
-export class Pollable {
+declare module 'wasi:io/poll@0.2.0' {
   /**
-   * This type does not have a public constructor.
+   * Poll for completion on a set of pollables.
+   * 
+   * This function takes a list of pollables, which identify I/O sources of
+   * interest, and waits until one or more of the events is ready for I/O.
+   * 
+   * The result `list<u32>` contains one or more indices of handles in the
+   * argument list that is ready for I/O.
+   * 
+   * If the list contains more elements than can be indexed with a `u32`
+   * value, this function traps.
+   * 
+   * A timeout can be implemented by adding a pollable from the
+   * wasi-clocks API to the list.
+   * 
+   * This function does not return a `result`; polling in itself does not
+   * do any I/O so it doesn't fail. If any of the I/O sources identified by
+   * the pollables has an error, it is indicated by marking the source as
+   * being reaedy for I/O.
    */
-  private constructor();
-  /**
-  * Return the readiness of a pollable. This function never blocks.
-  * 
-  * Returns `true` when the pollable is ready, and `false` otherwise.
-  */
-  ready(): boolean;
-  /**
-  * `block` returns immediately if the pollable is ready, and otherwise
-  * blocks until ready.
-  * 
-  * This function is equivalent to calling `poll.poll` on a list
-  * containing only this pollable.
-  */
-  block(): void;
+  export function poll(in_: Array<Pollable>): Uint32Array;
+  
+  export class Pollable implements Disposable {
+    /**
+     * This type does not have a public constructor.
+     */
+    private constructor();
+    /**
+    * Return the readiness of a pollable. This function never blocks.
+    * 
+    * Returns `true` when the pollable is ready, and `false` otherwise.
+    */
+    ready(): boolean;
+    /**
+    * `block` returns immediately if the pollable is ready, and otherwise
+    * blocks until ready.
+    * 
+    * This function is equivalent to calling `poll.poll` on a list
+    * containing only this pollable.
+    */
+    block(): void;
+    [Symbol.dispose](): void;
+  }
 }

--- a/templates/service-tcp-echo/service/generated/types/interfaces/wasi-io-streams.d.ts
+++ b/templates/service-tcp-echo/service/generated/types/interfaces/wasi-io-streams.d.ts
@@ -1,40 +1,45 @@
-/** @module Interface wasi:io/streams@0.2.3 **/
-export type Error = import('./wasi-io-error.js').Error;
-export type Pollable = import('./wasi-io-poll.js').Pollable;
-export type StreamError = StreamErrorLastOperationFailed | StreamErrorClosed;
-export interface StreamErrorLastOperationFailed {
-  tag: 'last-operation-failed',
-  val: Error,
-}
-export interface StreamErrorClosed {
-  tag: 'closed',
-}
-
-export class InputStream {
-  /**
-   * This type does not have a public constructor.
-   */
-  private constructor();
-  read(len: bigint): Uint8Array;
-  blockingRead(len: bigint): Uint8Array;
-  skip(len: bigint): bigint;
-  blockingSkip(len: bigint): bigint;
-  subscribe(): Pollable;
-}
-
-export class OutputStream {
-  /**
-   * This type does not have a public constructor.
-   */
-  private constructor();
-  checkWrite(): bigint;
-  write(contents: Uint8Array): void;
-  blockingWriteAndFlush(contents: Uint8Array): void;
-  flush(): void;
-  blockingFlush(): void;
-  subscribe(): Pollable;
-  writeZeroes(len: bigint): void;
-  blockingWriteZeroesAndFlush(len: bigint): void;
-  splice(src: InputStream, len: bigint): bigint;
-  blockingSplice(src: InputStream, len: bigint): bigint;
+/// <reference path="./wasi-io-error.d.ts" />
+/// <reference path="./wasi-io-poll.d.ts" />
+declare module 'wasi:io/streams@0.2.3' {
+  export type Error = import('wasi:io/error@0.2.3').Error;
+  export type Pollable = import('wasi:io/poll@0.2.3').Pollable;
+  export type StreamError = StreamErrorLastOperationFailed | StreamErrorClosed;
+  export interface StreamErrorLastOperationFailed {
+    tag: 'last-operation-failed',
+    val: Error,
+  }
+  export interface StreamErrorClosed {
+    tag: 'closed',
+  }
+  
+  export class InputStream implements Disposable {
+    /**
+     * This type does not have a public constructor.
+     */
+    private constructor();
+    read(len: bigint): Uint8Array;
+    blockingRead(len: bigint): Uint8Array;
+    skip(len: bigint): bigint;
+    blockingSkip(len: bigint): bigint;
+    subscribe(): Pollable;
+    [Symbol.dispose](): void;
+  }
+  
+  export class OutputStream implements Disposable {
+    /**
+     * This type does not have a public constructor.
+     */
+    private constructor();
+    checkWrite(): bigint;
+    write(contents: Uint8Array): void;
+    blockingWriteAndFlush(contents: Uint8Array): void;
+    flush(): void;
+    blockingFlush(): void;
+    subscribe(): Pollable;
+    writeZeroes(len: bigint): void;
+    blockingWriteZeroesAndFlush(len: bigint): void;
+    splice(src: InputStream, len: bigint): bigint;
+    blockingSplice(src: InputStream, len: bigint): bigint;
+    [Symbol.dispose](): void;
+  }
 }

--- a/templates/service-tcp-echo/service/generated/types/interfaces/wasi-sockets-instance-network.d.ts
+++ b/templates/service-tcp-echo/service/generated/types/interfaces/wasi-sockets-instance-network.d.ts
@@ -1,6 +1,8 @@
-/** @module Interface wasi:sockets/instance-network@0.2.3 **/
-/**
- * Get a handle to the default network.
- */
-export function instanceNetwork(): Network;
-export type Network = import('./wasi-sockets-network.js').Network;
+/// <reference path="./wasi-sockets-network.d.ts" />
+declare module 'wasi:sockets/instance-network@0.2.3' {
+  /**
+   * Get a handle to the default network.
+   */
+  export function instanceNetwork(): Network;
+  export type Network = import('wasi:sockets/network@0.2.3').Network;
+}

--- a/templates/service-tcp-echo/service/generated/types/interfaces/wasi-sockets-network.d.ts
+++ b/templates/service-tcp-echo/service/generated/types/interfaces/wasi-sockets-network.d.ts
@@ -1,164 +1,166 @@
-/** @module Interface wasi:sockets/network@0.2.3 **/
-/**
- * Error codes.
- * 
- * In theory, every API can return any error code.
- * In practice, API's typically only return the errors documented per API
- * combined with a couple of errors that are always possible:
- * - `unknown`
- * - `access-denied`
- * - `not-supported`
- * - `out-of-memory`
- * - `concurrency-conflict`
- * 
- * See each individual API for what the POSIX equivalents are. They sometimes differ per API.
- * # Variants
- * 
- * ## `"unknown"`
- * 
- * Unknown error
- * ## `"access-denied"`
- * 
- * Access denied.
- * 
- * POSIX equivalent: EACCES, EPERM
- * ## `"not-supported"`
- * 
- * The operation is not supported.
- * 
- * POSIX equivalent: EOPNOTSUPP
- * ## `"invalid-argument"`
- * 
- * One of the arguments is invalid.
- * 
- * POSIX equivalent: EINVAL
- * ## `"out-of-memory"`
- * 
- * Not enough memory to complete the operation.
- * 
- * POSIX equivalent: ENOMEM, ENOBUFS, EAI_MEMORY
- * ## `"timeout"`
- * 
- * The operation timed out before it could finish completely.
- * ## `"concurrency-conflict"`
- * 
- * This operation is incompatible with another asynchronous operation that is already in progress.
- * 
- * POSIX equivalent: EALREADY
- * ## `"not-in-progress"`
- * 
- * Trying to finish an asynchronous operation that:
- * - has not been started yet, or:
- * - was already finished by a previous `finish-*` call.
- * 
- * Note: this is scheduled to be removed when `future`s are natively supported.
- * ## `"would-block"`
- * 
- * The operation has been aborted because it could not be completed immediately.
- * 
- * Note: this is scheduled to be removed when `future`s are natively supported.
- * ## `"invalid-state"`
- * 
- * The operation is not valid in the socket's current state.
- * ## `"new-socket-limit"`
- * 
- * A new socket resource could not be created because of a system limit.
- * ## `"address-not-bindable"`
- * 
- * A bind operation failed because the provided address is not an address that the `network` can bind to.
- * ## `"address-in-use"`
- * 
- * A bind operation failed because the provided address is already in use or because there are no ephemeral ports available.
- * ## `"remote-unreachable"`
- * 
- * The remote address is not reachable
- * ## `"connection-refused"`
- * 
- * The TCP connection was forcefully rejected
- * ## `"connection-reset"`
- * 
- * The TCP connection was reset.
- * ## `"connection-aborted"`
- * 
- * A TCP connection was aborted.
- * ## `"datagram-too-large"`
- * 
- * The size of a datagram sent to a UDP socket exceeded the maximum
- * supported size.
- * ## `"name-unresolvable"`
- * 
- * Name does not exist or has no suitable associated IP addresses.
- * ## `"temporary-resolver-failure"`
- * 
- * A temporary failure in name resolution occurred.
- * ## `"permanent-resolver-failure"`
- * 
- * A permanent failure in name resolution occurred.
- */
-export type ErrorCode = 'unknown' | 'access-denied' | 'not-supported' | 'invalid-argument' | 'out-of-memory' | 'timeout' | 'concurrency-conflict' | 'not-in-progress' | 'would-block' | 'invalid-state' | 'new-socket-limit' | 'address-not-bindable' | 'address-in-use' | 'remote-unreachable' | 'connection-refused' | 'connection-reset' | 'connection-aborted' | 'datagram-too-large' | 'name-unresolvable' | 'temporary-resolver-failure' | 'permanent-resolver-failure';
-/**
- * # Variants
- * 
- * ## `"ipv4"`
- * 
- * Similar to `AF_INET` in POSIX.
- * ## `"ipv6"`
- * 
- * Similar to `AF_INET6` in POSIX.
- */
-export type IpAddressFamily = 'ipv4' | 'ipv6';
-export type Ipv4Address = [number, number, number, number];
-export type Ipv6Address = [number, number, number, number, number, number, number, number];
-export type IpAddress = IpAddressIpv4 | IpAddressIpv6;
-export interface IpAddressIpv4 {
-  tag: 'ipv4',
-  val: Ipv4Address,
-}
-export interface IpAddressIpv6 {
-  tag: 'ipv6',
-  val: Ipv6Address,
-}
-export interface Ipv4SocketAddress {
+declare module 'wasi:sockets/network@0.2.3' {
   /**
-   * sin_port
+   * Error codes.
+   * 
+   * In theory, every API can return any error code.
+   * In practice, API's typically only return the errors documented per API
+   * combined with a couple of errors that are always possible:
+   * - `unknown`
+   * - `access-denied`
+   * - `not-supported`
+   * - `out-of-memory`
+   * - `concurrency-conflict`
+   * 
+   * See each individual API for what the POSIX equivalents are. They sometimes differ per API.
+   * # Variants
+   * 
+   * ## `"unknown"`
+   * 
+   * Unknown error
+   * ## `"access-denied"`
+   * 
+   * Access denied.
+   * 
+   * POSIX equivalent: EACCES, EPERM
+   * ## `"not-supported"`
+   * 
+   * The operation is not supported.
+   * 
+   * POSIX equivalent: EOPNOTSUPP
+   * ## `"invalid-argument"`
+   * 
+   * One of the arguments is invalid.
+   * 
+   * POSIX equivalent: EINVAL
+   * ## `"out-of-memory"`
+   * 
+   * Not enough memory to complete the operation.
+   * 
+   * POSIX equivalent: ENOMEM, ENOBUFS, EAI_MEMORY
+   * ## `"timeout"`
+   * 
+   * The operation timed out before it could finish completely.
+   * ## `"concurrency-conflict"`
+   * 
+   * This operation is incompatible with another asynchronous operation that is already in progress.
+   * 
+   * POSIX equivalent: EALREADY
+   * ## `"not-in-progress"`
+   * 
+   * Trying to finish an asynchronous operation that:
+   * - has not been started yet, or:
+   * - was already finished by a previous `finish-*` call.
+   * 
+   * Note: this is scheduled to be removed when `future`s are natively supported.
+   * ## `"would-block"`
+   * 
+   * The operation has been aborted because it could not be completed immediately.
+   * 
+   * Note: this is scheduled to be removed when `future`s are natively supported.
+   * ## `"invalid-state"`
+   * 
+   * The operation is not valid in the socket's current state.
+   * ## `"new-socket-limit"`
+   * 
+   * A new socket resource could not be created because of a system limit.
+   * ## `"address-not-bindable"`
+   * 
+   * A bind operation failed because the provided address is not an address that the `network` can bind to.
+   * ## `"address-in-use"`
+   * 
+   * A bind operation failed because the provided address is already in use or because there are no ephemeral ports available.
+   * ## `"remote-unreachable"`
+   * 
+   * The remote address is not reachable
+   * ## `"connection-refused"`
+   * 
+   * The TCP connection was forcefully rejected
+   * ## `"connection-reset"`
+   * 
+   * The TCP connection was reset.
+   * ## `"connection-aborted"`
+   * 
+   * A TCP connection was aborted.
+   * ## `"datagram-too-large"`
+   * 
+   * The size of a datagram sent to a UDP socket exceeded the maximum
+   * supported size.
+   * ## `"name-unresolvable"`
+   * 
+   * Name does not exist or has no suitable associated IP addresses.
+   * ## `"temporary-resolver-failure"`
+   * 
+   * A temporary failure in name resolution occurred.
+   * ## `"permanent-resolver-failure"`
+   * 
+   * A permanent failure in name resolution occurred.
    */
-  port: number,
+  export type ErrorCode = 'unknown' | 'access-denied' | 'not-supported' | 'invalid-argument' | 'out-of-memory' | 'timeout' | 'concurrency-conflict' | 'not-in-progress' | 'would-block' | 'invalid-state' | 'new-socket-limit' | 'address-not-bindable' | 'address-in-use' | 'remote-unreachable' | 'connection-refused' | 'connection-reset' | 'connection-aborted' | 'datagram-too-large' | 'name-unresolvable' | 'temporary-resolver-failure' | 'permanent-resolver-failure';
   /**
-   * sin_addr
+   * # Variants
+   * 
+   * ## `"ipv4"`
+   * 
+   * Similar to `AF_INET` in POSIX.
+   * ## `"ipv6"`
+   * 
+   * Similar to `AF_INET6` in POSIX.
    */
-  address: Ipv4Address,
-}
-export interface Ipv6SocketAddress {
-  /**
-   * sin6_port
-   */
-  port: number,
-  /**
-   * sin6_flowinfo
-   */
-  flowInfo: number,
-  /**
-   * sin6_addr
-   */
-  address: Ipv6Address,
-  /**
-   * sin6_scope_id
-   */
-  scopeId: number,
-}
-export type IpSocketAddress = IpSocketAddressIpv4 | IpSocketAddressIpv6;
-export interface IpSocketAddressIpv4 {
-  tag: 'ipv4',
-  val: Ipv4SocketAddress,
-}
-export interface IpSocketAddressIpv6 {
-  tag: 'ipv6',
-  val: Ipv6SocketAddress,
-}
-
-export class Network {
-  /**
-   * This type does not have a public constructor.
-   */
-  private constructor();
+  export type IpAddressFamily = 'ipv4' | 'ipv6';
+  export type Ipv4Address = [number, number, number, number];
+  export type Ipv6Address = [number, number, number, number, number, number, number, number];
+  export type IpAddress = IpAddressIpv4 | IpAddressIpv6;
+  export interface IpAddressIpv4 {
+    tag: 'ipv4',
+    val: Ipv4Address,
+  }
+  export interface IpAddressIpv6 {
+    tag: 'ipv6',
+    val: Ipv6Address,
+  }
+  export interface Ipv4SocketAddress {
+    /**
+     * sin_port
+     */
+    port: number,
+    /**
+     * sin_addr
+     */
+    address: Ipv4Address,
+  }
+  export interface Ipv6SocketAddress {
+    /**
+     * sin6_port
+     */
+    port: number,
+    /**
+     * sin6_flowinfo
+     */
+    flowInfo: number,
+    /**
+     * sin6_addr
+     */
+    address: Ipv6Address,
+    /**
+     * sin6_scope_id
+     */
+    scopeId: number,
+  }
+  export type IpSocketAddress = IpSocketAddressIpv4 | IpSocketAddressIpv6;
+  export interface IpSocketAddressIpv4 {
+    tag: 'ipv4',
+    val: Ipv4SocketAddress,
+  }
+  export interface IpSocketAddressIpv6 {
+    tag: 'ipv6',
+    val: Ipv6SocketAddress,
+  }
+  
+  export class Network implements Disposable {
+    /**
+     * This type does not have a public constructor.
+     */
+    private constructor();
+    [Symbol.dispose](): void;
+  }
 }

--- a/templates/service-tcp-echo/service/generated/types/interfaces/wasi-sockets-tcp-create-socket.d.ts
+++ b/templates/service-tcp-echo/service/generated/types/interfaces/wasi-sockets-tcp-create-socket.d.ts
@@ -1,28 +1,31 @@
-/** @module Interface wasi:sockets/tcp-create-socket@0.2.3 **/
-/**
- * Create a new TCP socket.
- * 
- * Similar to `socket(AF_INET or AF_INET6, SOCK_STREAM, IPPROTO_TCP)` in POSIX.
- * On IPv6 sockets, IPV6_V6ONLY is enabled by default and can't be configured otherwise.
- * 
- * This function does not require a network capability handle. This is considered to be safe because
- * at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`connect`
- * is called, the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
- * 
- * All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
- * 
- * # Typical errors
- * - `not-supported`:     The specified `address-family` is not supported. (EAFNOSUPPORT)
- * - `new-socket-limit`:  The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
- * 
- * # References
- * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
- * - <https://man7.org/linux/man-pages/man2/socket.2.html>
- * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
- * - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
- */
-export function createTcpSocket(addressFamily: IpAddressFamily): TcpSocket;
-export type Network = import('./wasi-sockets-network.js').Network;
-export type ErrorCode = import('./wasi-sockets-network.js').ErrorCode;
-export type IpAddressFamily = import('./wasi-sockets-network.js').IpAddressFamily;
-export type TcpSocket = import('./wasi-sockets-tcp.js').TcpSocket;
+/// <reference path="./wasi-sockets-network.d.ts" />
+/// <reference path="./wasi-sockets-tcp.d.ts" />
+declare module 'wasi:sockets/tcp-create-socket@0.2.3' {
+  /**
+   * Create a new TCP socket.
+   * 
+   * Similar to `socket(AF_INET or AF_INET6, SOCK_STREAM, IPPROTO_TCP)` in POSIX.
+   * On IPv6 sockets, IPV6_V6ONLY is enabled by default and can't be configured otherwise.
+   * 
+   * This function does not require a network capability handle. This is considered to be safe because
+   * at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`connect`
+   * is called, the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
+   * 
+   * All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
+   * 
+   * # Typical errors
+   * - `not-supported`:     The specified `address-family` is not supported. (EAFNOSUPPORT)
+   * - `new-socket-limit`:  The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
+   * 
+   * # References
+   * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
+   * - <https://man7.org/linux/man-pages/man2/socket.2.html>
+   * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
+   * - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
+   */
+  export function createTcpSocket(addressFamily: IpAddressFamily): TcpSocket;
+  export type Network = import('wasi:sockets/network@0.2.3').Network;
+  export type ErrorCode = import('wasi:sockets/network@0.2.3').ErrorCode;
+  export type IpAddressFamily = import('wasi:sockets/network@0.2.3').IpAddressFamily;
+  export type TcpSocket = import('wasi:sockets/tcp@0.2.3').TcpSocket;
+}

--- a/templates/service-tcp-echo/service/generated/types/interfaces/wasi-sockets-tcp.d.ts
+++ b/templates/service-tcp-echo/service/generated/types/interfaces/wasi-sockets-tcp.d.ts
@@ -1,359 +1,365 @@
-/** @module Interface wasi:sockets/tcp@0.2.3 **/
-export type InputStream = import('./wasi-io-streams.js').InputStream;
-export type OutputStream = import('./wasi-io-streams.js').OutputStream;
-export type Pollable = import('./wasi-io-poll.js').Pollable;
-export type Duration = import('./wasi-clocks-monotonic-clock.js').Duration;
-export type Network = import('./wasi-sockets-network.js').Network;
-export type ErrorCode = import('./wasi-sockets-network.js').ErrorCode;
-export type IpSocketAddress = import('./wasi-sockets-network.js').IpSocketAddress;
-export type IpAddressFamily = import('./wasi-sockets-network.js').IpAddressFamily;
-/**
- * # Variants
- * 
- * ## `"receive"`
- * 
- * Similar to `SHUT_RD` in POSIX.
- * ## `"send"`
- * 
- * Similar to `SHUT_WR` in POSIX.
- * ## `"both"`
- * 
- * Similar to `SHUT_RDWR` in POSIX.
- */
-export type ShutdownType = 'receive' | 'send' | 'both';
-
-export class TcpSocket {
+/// <reference path="./wasi-clocks-monotonic-clock.d.ts" />
+/// <reference path="./wasi-io-poll.d.ts" />
+/// <reference path="./wasi-io-streams.d.ts" />
+/// <reference path="./wasi-sockets-network.d.ts" />
+declare module 'wasi:sockets/tcp@0.2.3' {
+  export type InputStream = import('wasi:io/streams@0.2.3').InputStream;
+  export type OutputStream = import('wasi:io/streams@0.2.3').OutputStream;
+  export type Pollable = import('wasi:io/poll@0.2.3').Pollable;
+  export type Duration = import('wasi:clocks/monotonic-clock@0.2.3').Duration;
+  export type Network = import('wasi:sockets/network@0.2.3').Network;
+  export type ErrorCode = import('wasi:sockets/network@0.2.3').ErrorCode;
+  export type IpSocketAddress = import('wasi:sockets/network@0.2.3').IpSocketAddress;
+  export type IpAddressFamily = import('wasi:sockets/network@0.2.3').IpAddressFamily;
   /**
-   * This type does not have a public constructor.
+   * # Variants
+   * 
+   * ## `"receive"`
+   * 
+   * Similar to `SHUT_RD` in POSIX.
+   * ## `"send"`
+   * 
+   * Similar to `SHUT_WR` in POSIX.
+   * ## `"both"`
+   * 
+   * Similar to `SHUT_RDWR` in POSIX.
    */
-  private constructor();
-  /**
-  * Bind the socket to a specific network on the provided IP address and port.
-  * 
-  * If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
-  * network interface(s) to bind to.
-  * If the TCP/UDP port is zero, the socket will be bound to a random free port.
-  * 
-  * Bind can be attempted multiple times on the same socket, even with
-  * different arguments on each iteration. But never concurrently and
-  * only as long as the previous bind failed. Once a bind succeeds, the
-  * binding can't be changed anymore.
-  * 
-  * # Typical errors
-  * - `invalid-argument`:          The `local-address` has the wrong address family. (EAFNOSUPPORT, EFAULT on Windows)
-  * - `invalid-argument`:          `local-address` is not a unicast address. (EINVAL)
-  * - `invalid-argument`:          `local-address` is an IPv4-mapped IPv6 address. (EINVAL)
-  * - `invalid-state`:             The socket is already bound. (EINVAL)
-  * - `address-in-use`:            No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
-  * - `address-in-use`:            Address is already in use. (EADDRINUSE)
-  * - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
-  * - `not-in-progress`:           A `bind` operation is not in progress.
-  * - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
-  * 
-  * # Implementors note
-  * When binding to a non-zero port, this bind operation shouldn't be affected by the TIME_WAIT
-  * state of a recently closed socket on the same local address. In practice this means that the SO_REUSEADDR
-  * socket option should be set implicitly on all platforms, except on Windows where this is the default behavior
-  * and SO_REUSEADDR performs something different entirely.
-  * 
-  * Unlike in POSIX, in WASI the bind operation is async. This enables
-  * interactive WASI hosts to inject permission prompts. Runtimes that
-  * don't want to make use of this ability can simply call the native
-  * `bind` as part of either `start-bind` or `finish-bind`.
-  * 
-  * # References
-  * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
-  * - <https://man7.org/linux/man-pages/man2/bind.2.html>
-  * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
-  * - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
-  */
-  startBind(network: Network, localAddress: IpSocketAddress): void;
-  finishBind(): void;
-  /**
-  * Connect to a remote endpoint.
-  * 
-  * On success:
-  * - the socket is transitioned into the `connected` state.
-  * - a pair of streams is returned that can be used to read & write to the connection
-  * 
-  * After a failed connection attempt, the socket will be in the `closed`
-  * state and the only valid action left is to `drop` the socket. A single
-  * socket can not be used to connect more than once.
-  * 
-  * # Typical errors
-  * - `invalid-argument`:          The `remote-address` has the wrong address family. (EAFNOSUPPORT)
-  * - `invalid-argument`:          `remote-address` is not a unicast address. (EINVAL, ENETUNREACH on Linux, EAFNOSUPPORT on MacOS)
-  * - `invalid-argument`:          `remote-address` is an IPv4-mapped IPv6 address. (EINVAL, EADDRNOTAVAIL on Illumos)
-  * - `invalid-argument`:          The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EADDRNOTAVAIL on Windows)
-  * - `invalid-argument`:          The port in `remote-address` is set to 0. (EADDRNOTAVAIL on Windows)
-  * - `invalid-argument`:          The socket is already attached to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
-  * - `invalid-state`:             The socket is already in the `connected` state. (EISCONN)
-  * - `invalid-state`:             The socket is already in the `listening` state. (EOPNOTSUPP, EINVAL on Windows)
-  * - `timeout`:                   Connection timed out. (ETIMEDOUT)
-  * - `connection-refused`:        The connection was forcefully rejected. (ECONNREFUSED)
-  * - `connection-reset`:          The connection was reset. (ECONNRESET)
-  * - `connection-aborted`:        The connection was aborted. (ECONNABORTED)
-  * - `remote-unreachable`:        The remote address is not reachable. (EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN, ENONET)
-  * - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
-  * - `not-in-progress`:           A connect operation is not in progress.
-  * - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
-  * 
-  * # Implementors note
-  * The POSIX equivalent of `start-connect` is the regular `connect` syscall.
-  * Because all WASI sockets are non-blocking this is expected to return
-  * EINPROGRESS, which should be translated to `ok()` in WASI.
-  * 
-  * The POSIX equivalent of `finish-connect` is a `poll` for event `POLLOUT`
-  * with a timeout of 0 on the socket descriptor. Followed by a check for
-  * the `SO_ERROR` socket option, in case the poll signaled readiness.
-  * 
-  * # References
-  * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
-  * - <https://man7.org/linux/man-pages/man2/connect.2.html>
-  * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
-  * - <https://man.freebsd.org/cgi/man.cgi?connect>
-  */
-  startConnect(network: Network, remoteAddress: IpSocketAddress): void;
-  finishConnect(): [InputStream, OutputStream];
-  /**
-  * Start listening for new connections.
-  * 
-  * Transitions the socket into the `listening` state.
-  * 
-  * Unlike POSIX, the socket must already be explicitly bound.
-  * 
-  * # Typical errors
-  * - `invalid-state`:             The socket is not bound to any local address. (EDESTADDRREQ)
-  * - `invalid-state`:             The socket is already in the `connected` state. (EISCONN, EINVAL on BSD)
-  * - `invalid-state`:             The socket is already in the `listening` state.
-  * - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE)
-  * - `not-in-progress`:           A listen operation is not in progress.
-  * - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
-  * 
-  * # Implementors note
-  * Unlike in POSIX, in WASI the listen operation is async. This enables
-  * interactive WASI hosts to inject permission prompts. Runtimes that
-  * don't want to make use of this ability can simply call the native
-  * `listen` as part of either `start-listen` or `finish-listen`.
-  * 
-  * # References
-  * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html>
-  * - <https://man7.org/linux/man-pages/man2/listen.2.html>
-  * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen>
-  * - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
-  */
-  startListen(): void;
-  finishListen(): void;
-  /**
-  * Accept a new client socket.
-  * 
-  * The returned socket is bound and in the `connected` state. The following properties are inherited from the listener socket:
-  * - `address-family`
-  * - `keep-alive-enabled`
-  * - `keep-alive-idle-time`
-  * - `keep-alive-interval`
-  * - `keep-alive-count`
-  * - `hop-limit`
-  * - `receive-buffer-size`
-  * - `send-buffer-size`
-  * 
-  * On success, this function returns the newly accepted client socket along with
-  * a pair of streams that can be used to read & write to the connection.
-  * 
-  * # Typical errors
-  * - `invalid-state`:      Socket is not in the `listening` state. (EINVAL)
-  * - `would-block`:        No pending connections at the moment. (EWOULDBLOCK, EAGAIN)
-  * - `connection-aborted`: An incoming connection was pending, but was terminated by the client before this listener could accept it. (ECONNABORTED)
-  * - `new-socket-limit`:   The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
-  * 
-  * # References
-  * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html>
-  * - <https://man7.org/linux/man-pages/man2/accept.2.html>
-  * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept>
-  * - <https://man.freebsd.org/cgi/man.cgi?query=accept&sektion=2>
-  */
-  accept(): [TcpSocket, InputStream, OutputStream];
-  /**
-  * Get the bound local address.
-  * 
-  * POSIX mentions:
-  * > If the socket has not been bound to a local name, the value
-  * > stored in the object pointed to by `address` is unspecified.
-  * 
-  * WASI is stricter and requires `local-address` to return `invalid-state` when the socket hasn't been bound yet.
-  * 
-  * # Typical errors
-  * - `invalid-state`: The socket is not bound to any local address.
-  * 
-  * # References
-  * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
-  * - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
-  * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
-  * - <https://man.freebsd.org/cgi/man.cgi?getsockname>
-  */
-  localAddress(): IpSocketAddress;
-  /**
-  * Get the remote address.
-  * 
-  * # Typical errors
-  * - `invalid-state`: The socket is not connected to a remote address. (ENOTCONN)
-  * 
-  * # References
-  * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
-  * - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
-  * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
-  * - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
-  */
-  remoteAddress(): IpSocketAddress;
-  /**
-  * Whether the socket is in the `listening` state.
-  * 
-  * Equivalent to the SO_ACCEPTCONN socket option.
-  */
-  isListening(): boolean;
-  /**
-  * Whether this is a IPv4 or IPv6 socket.
-  * 
-  * Equivalent to the SO_DOMAIN socket option.
-  */
-  addressFamily(): IpAddressFamily;
-  /**
-  * Hints the desired listen queue size. Implementations are free to ignore this.
-  * 
-  * If the provided value is 0, an `invalid-argument` error is returned.
-  * Any other value will never cause an error, but it might be silently clamped and/or rounded.
-  * 
-  * # Typical errors
-  * - `not-supported`:        (set) The platform does not support changing the backlog size after the initial listen.
-  * - `invalid-argument`:     (set) The provided value was 0.
-  * - `invalid-state`:        (set) The socket is in the `connect-in-progress` or `connected` state.
-  */
-  setListenBacklogSize(value: bigint): void;
-  /**
-  * Enables or disables keepalive.
-  * 
-  * The keepalive behavior can be adjusted using:
-  * - `keep-alive-idle-time`
-  * - `keep-alive-interval`
-  * - `keep-alive-count`
-  * These properties can be configured while `keep-alive-enabled` is false, but only come into effect when `keep-alive-enabled` is true.
-  * 
-  * Equivalent to the SO_KEEPALIVE socket option.
-  */
-  keepAliveEnabled(): boolean;
-  setKeepAliveEnabled(value: boolean): void;
-  /**
-  * Amount of time the connection has to be idle before TCP starts sending keepalive packets.
-  * 
-  * If the provided value is 0, an `invalid-argument` error is returned.
-  * Any other value will never cause an error, but it might be silently clamped and/or rounded.
-  * I.e. after setting a value, reading the same setting back may return a different value.
-  * 
-  * Equivalent to the TCP_KEEPIDLE socket option. (TCP_KEEPALIVE on MacOS)
-  * 
-  * # Typical errors
-  * - `invalid-argument`:     (set) The provided value was 0.
-  */
-  keepAliveIdleTime(): Duration;
-  setKeepAliveIdleTime(value: Duration): void;
-  /**
-  * The time between keepalive packets.
-  * 
-  * If the provided value is 0, an `invalid-argument` error is returned.
-  * Any other value will never cause an error, but it might be silently clamped and/or rounded.
-  * I.e. after setting a value, reading the same setting back may return a different value.
-  * 
-  * Equivalent to the TCP_KEEPINTVL socket option.
-  * 
-  * # Typical errors
-  * - `invalid-argument`:     (set) The provided value was 0.
-  */
-  keepAliveInterval(): Duration;
-  setKeepAliveInterval(value: Duration): void;
-  /**
-  * The maximum amount of keepalive packets TCP should send before aborting the connection.
-  * 
-  * If the provided value is 0, an `invalid-argument` error is returned.
-  * Any other value will never cause an error, but it might be silently clamped and/or rounded.
-  * I.e. after setting a value, reading the same setting back may return a different value.
-  * 
-  * Equivalent to the TCP_KEEPCNT socket option.
-  * 
-  * # Typical errors
-  * - `invalid-argument`:     (set) The provided value was 0.
-  */
-  keepAliveCount(): number;
-  setKeepAliveCount(value: number): void;
-  /**
-  * Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
-  * 
-  * If the provided value is 0, an `invalid-argument` error is returned.
-  * 
-  * # Typical errors
-  * - `invalid-argument`:     (set) The TTL value must be 1 or higher.
-  */
-  hopLimit(): number;
-  setHopLimit(value: number): void;
-  /**
-  * The kernel buffer space reserved for sends/receives on this socket.
-  * 
-  * If the provided value is 0, an `invalid-argument` error is returned.
-  * Any other value will never cause an error, but it might be silently clamped and/or rounded.
-  * I.e. after setting a value, reading the same setting back may return a different value.
-  * 
-  * Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
-  * 
-  * # Typical errors
-  * - `invalid-argument`:     (set) The provided value was 0.
-  */
-  receiveBufferSize(): bigint;
-  setReceiveBufferSize(value: bigint): void;
-  sendBufferSize(): bigint;
-  setSendBufferSize(value: bigint): void;
-  /**
-  * Create a `pollable` which can be used to poll for, or block on,
-  * completion of any of the asynchronous operations of this socket.
-  * 
-  * When `finish-bind`, `finish-listen`, `finish-connect` or `accept`
-  * return `error(would-block)`, this pollable can be used to wait for
-  * their success or failure, after which the method can be retried.
-  * 
-  * The pollable is not limited to the async operation that happens to be
-  * in progress at the time of calling `subscribe` (if any). Theoretically,
-  * `subscribe` only has to be called once per socket and can then be
-  * (re)used for the remainder of the socket's lifetime.
-  * 
-  * See <https://github.com/WebAssembly/wasi-sockets/blob/main/TcpSocketOperationalSemantics.md#pollable-readiness>
-  * for more information.
-  * 
-  * Note: this function is here for WASI 0.2 only.
-  * It's planned to be removed when `future` is natively supported in Preview3.
-  */
-  subscribe(): Pollable;
-  /**
-  * Initiate a graceful shutdown.
-  * 
-  * - `receive`: The socket is not expecting to receive any data from
-  * the peer. The `input-stream` associated with this socket will be
-  * closed. Any data still in the receive queue at time of calling
-  * this method will be discarded.
-  * - `send`: The socket has no more data to send to the peer. The `output-stream`
-  * associated with this socket will be closed and a FIN packet will be sent.
-  * - `both`: Same effect as `receive` & `send` combined.
-  * 
-  * This function is idempotent; shutting down a direction more than once
-  * has no effect and returns `ok`.
-  * 
-  * The shutdown function does not close (drop) the socket.
-  * 
-  * # Typical errors
-  * - `invalid-state`: The socket is not in the `connected` state. (ENOTCONN)
-  * 
-  * # References
-  * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html>
-  * - <https://man7.org/linux/man-pages/man2/shutdown.2.html>
-  * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown>
-  * - <https://man.freebsd.org/cgi/man.cgi?query=shutdown&sektion=2>
-  */
-  shutdown(shutdownType: ShutdownType): void;
+  export type ShutdownType = 'receive' | 'send' | 'both';
+  
+  export class TcpSocket implements Disposable {
+    /**
+     * This type does not have a public constructor.
+     */
+    private constructor();
+    /**
+    * Bind the socket to a specific network on the provided IP address and port.
+    * 
+    * If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
+    * network interface(s) to bind to.
+    * If the TCP/UDP port is zero, the socket will be bound to a random free port.
+    * 
+    * Bind can be attempted multiple times on the same socket, even with
+    * different arguments on each iteration. But never concurrently and
+    * only as long as the previous bind failed. Once a bind succeeds, the
+    * binding can't be changed anymore.
+    * 
+    * # Typical errors
+    * - `invalid-argument`:          The `local-address` has the wrong address family. (EAFNOSUPPORT, EFAULT on Windows)
+    * - `invalid-argument`:          `local-address` is not a unicast address. (EINVAL)
+    * - `invalid-argument`:          `local-address` is an IPv4-mapped IPv6 address. (EINVAL)
+    * - `invalid-state`:             The socket is already bound. (EINVAL)
+    * - `address-in-use`:            No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
+    * - `address-in-use`:            Address is already in use. (EADDRINUSE)
+    * - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
+    * - `not-in-progress`:           A `bind` operation is not in progress.
+    * - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+    * 
+    * # Implementors note
+    * When binding to a non-zero port, this bind operation shouldn't be affected by the TIME_WAIT
+    * state of a recently closed socket on the same local address. In practice this means that the SO_REUSEADDR
+    * socket option should be set implicitly on all platforms, except on Windows where this is the default behavior
+    * and SO_REUSEADDR performs something different entirely.
+    * 
+    * Unlike in POSIX, in WASI the bind operation is async. This enables
+    * interactive WASI hosts to inject permission prompts. Runtimes that
+    * don't want to make use of this ability can simply call the native
+    * `bind` as part of either `start-bind` or `finish-bind`.
+    * 
+    * # References
+    * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
+    * - <https://man7.org/linux/man-pages/man2/bind.2.html>
+    * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
+    * - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
+    */
+    startBind(network: Network, localAddress: IpSocketAddress): void;
+    finishBind(): void;
+    /**
+    * Connect to a remote endpoint.
+    * 
+    * On success:
+    * - the socket is transitioned into the `connected` state.
+    * - a pair of streams is returned that can be used to read & write to the connection
+    * 
+    * After a failed connection attempt, the socket will be in the `closed`
+    * state and the only valid action left is to `drop` the socket. A single
+    * socket can not be used to connect more than once.
+    * 
+    * # Typical errors
+    * - `invalid-argument`:          The `remote-address` has the wrong address family. (EAFNOSUPPORT)
+    * - `invalid-argument`:          `remote-address` is not a unicast address. (EINVAL, ENETUNREACH on Linux, EAFNOSUPPORT on MacOS)
+    * - `invalid-argument`:          `remote-address` is an IPv4-mapped IPv6 address. (EINVAL, EADDRNOTAVAIL on Illumos)
+    * - `invalid-argument`:          The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EADDRNOTAVAIL on Windows)
+    * - `invalid-argument`:          The port in `remote-address` is set to 0. (EADDRNOTAVAIL on Windows)
+    * - `invalid-argument`:          The socket is already attached to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
+    * - `invalid-state`:             The socket is already in the `connected` state. (EISCONN)
+    * - `invalid-state`:             The socket is already in the `listening` state. (EOPNOTSUPP, EINVAL on Windows)
+    * - `timeout`:                   Connection timed out. (ETIMEDOUT)
+    * - `connection-refused`:        The connection was forcefully rejected. (ECONNREFUSED)
+    * - `connection-reset`:          The connection was reset. (ECONNRESET)
+    * - `connection-aborted`:        The connection was aborted. (ECONNABORTED)
+    * - `remote-unreachable`:        The remote address is not reachable. (EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN, ENONET)
+    * - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
+    * - `not-in-progress`:           A connect operation is not in progress.
+    * - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+    * 
+    * # Implementors note
+    * The POSIX equivalent of `start-connect` is the regular `connect` syscall.
+    * Because all WASI sockets are non-blocking this is expected to return
+    * EINPROGRESS, which should be translated to `ok()` in WASI.
+    * 
+    * The POSIX equivalent of `finish-connect` is a `poll` for event `POLLOUT`
+    * with a timeout of 0 on the socket descriptor. Followed by a check for
+    * the `SO_ERROR` socket option, in case the poll signaled readiness.
+    * 
+    * # References
+    * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
+    * - <https://man7.org/linux/man-pages/man2/connect.2.html>
+    * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
+    * - <https://man.freebsd.org/cgi/man.cgi?connect>
+    */
+    startConnect(network: Network, remoteAddress: IpSocketAddress): void;
+    finishConnect(): [InputStream, OutputStream];
+    /**
+    * Start listening for new connections.
+    * 
+    * Transitions the socket into the `listening` state.
+    * 
+    * Unlike POSIX, the socket must already be explicitly bound.
+    * 
+    * # Typical errors
+    * - `invalid-state`:             The socket is not bound to any local address. (EDESTADDRREQ)
+    * - `invalid-state`:             The socket is already in the `connected` state. (EISCONN, EINVAL on BSD)
+    * - `invalid-state`:             The socket is already in the `listening` state.
+    * - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE)
+    * - `not-in-progress`:           A listen operation is not in progress.
+    * - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+    * 
+    * # Implementors note
+    * Unlike in POSIX, in WASI the listen operation is async. This enables
+    * interactive WASI hosts to inject permission prompts. Runtimes that
+    * don't want to make use of this ability can simply call the native
+    * `listen` as part of either `start-listen` or `finish-listen`.
+    * 
+    * # References
+    * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html>
+    * - <https://man7.org/linux/man-pages/man2/listen.2.html>
+    * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen>
+    * - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
+    */
+    startListen(): void;
+    finishListen(): void;
+    /**
+    * Accept a new client socket.
+    * 
+    * The returned socket is bound and in the `connected` state. The following properties are inherited from the listener socket:
+    * - `address-family`
+    * - `keep-alive-enabled`
+    * - `keep-alive-idle-time`
+    * - `keep-alive-interval`
+    * - `keep-alive-count`
+    * - `hop-limit`
+    * - `receive-buffer-size`
+    * - `send-buffer-size`
+    * 
+    * On success, this function returns the newly accepted client socket along with
+    * a pair of streams that can be used to read & write to the connection.
+    * 
+    * # Typical errors
+    * - `invalid-state`:      Socket is not in the `listening` state. (EINVAL)
+    * - `would-block`:        No pending connections at the moment. (EWOULDBLOCK, EAGAIN)
+    * - `connection-aborted`: An incoming connection was pending, but was terminated by the client before this listener could accept it. (ECONNABORTED)
+    * - `new-socket-limit`:   The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
+    * 
+    * # References
+    * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html>
+    * - <https://man7.org/linux/man-pages/man2/accept.2.html>
+    * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept>
+    * - <https://man.freebsd.org/cgi/man.cgi?query=accept&sektion=2>
+    */
+    accept(): [TcpSocket, InputStream, OutputStream];
+    /**
+    * Get the bound local address.
+    * 
+    * POSIX mentions:
+    * > If the socket has not been bound to a local name, the value
+    * > stored in the object pointed to by `address` is unspecified.
+    * 
+    * WASI is stricter and requires `local-address` to return `invalid-state` when the socket hasn't been bound yet.
+    * 
+    * # Typical errors
+    * - `invalid-state`: The socket is not bound to any local address.
+    * 
+    * # References
+    * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
+    * - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
+    * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
+    * - <https://man.freebsd.org/cgi/man.cgi?getsockname>
+    */
+    localAddress(): IpSocketAddress;
+    /**
+    * Get the remote address.
+    * 
+    * # Typical errors
+    * - `invalid-state`: The socket is not connected to a remote address. (ENOTCONN)
+    * 
+    * # References
+    * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
+    * - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
+    * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
+    * - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
+    */
+    remoteAddress(): IpSocketAddress;
+    /**
+    * Whether the socket is in the `listening` state.
+    * 
+    * Equivalent to the SO_ACCEPTCONN socket option.
+    */
+    isListening(): boolean;
+    /**
+    * Whether this is a IPv4 or IPv6 socket.
+    * 
+    * Equivalent to the SO_DOMAIN socket option.
+    */
+    addressFamily(): IpAddressFamily;
+    /**
+    * Hints the desired listen queue size. Implementations are free to ignore this.
+    * 
+    * If the provided value is 0, an `invalid-argument` error is returned.
+    * Any other value will never cause an error, but it might be silently clamped and/or rounded.
+    * 
+    * # Typical errors
+    * - `not-supported`:        (set) The platform does not support changing the backlog size after the initial listen.
+    * - `invalid-argument`:     (set) The provided value was 0.
+    * - `invalid-state`:        (set) The socket is in the `connect-in-progress` or `connected` state.
+    */
+    setListenBacklogSize(value: bigint): void;
+    /**
+    * Enables or disables keepalive.
+    * 
+    * The keepalive behavior can be adjusted using:
+    * - `keep-alive-idle-time`
+    * - `keep-alive-interval`
+    * - `keep-alive-count`
+    * These properties can be configured while `keep-alive-enabled` is false, but only come into effect when `keep-alive-enabled` is true.
+    * 
+    * Equivalent to the SO_KEEPALIVE socket option.
+    */
+    keepAliveEnabled(): boolean;
+    setKeepAliveEnabled(value: boolean): void;
+    /**
+    * Amount of time the connection has to be idle before TCP starts sending keepalive packets.
+    * 
+    * If the provided value is 0, an `invalid-argument` error is returned.
+    * Any other value will never cause an error, but it might be silently clamped and/or rounded.
+    * I.e. after setting a value, reading the same setting back may return a different value.
+    * 
+    * Equivalent to the TCP_KEEPIDLE socket option. (TCP_KEEPALIVE on MacOS)
+    * 
+    * # Typical errors
+    * - `invalid-argument`:     (set) The provided value was 0.
+    */
+    keepAliveIdleTime(): Duration;
+    setKeepAliveIdleTime(value: Duration): void;
+    /**
+    * The time between keepalive packets.
+    * 
+    * If the provided value is 0, an `invalid-argument` error is returned.
+    * Any other value will never cause an error, but it might be silently clamped and/or rounded.
+    * I.e. after setting a value, reading the same setting back may return a different value.
+    * 
+    * Equivalent to the TCP_KEEPINTVL socket option.
+    * 
+    * # Typical errors
+    * - `invalid-argument`:     (set) The provided value was 0.
+    */
+    keepAliveInterval(): Duration;
+    setKeepAliveInterval(value: Duration): void;
+    /**
+    * The maximum amount of keepalive packets TCP should send before aborting the connection.
+    * 
+    * If the provided value is 0, an `invalid-argument` error is returned.
+    * Any other value will never cause an error, but it might be silently clamped and/or rounded.
+    * I.e. after setting a value, reading the same setting back may return a different value.
+    * 
+    * Equivalent to the TCP_KEEPCNT socket option.
+    * 
+    * # Typical errors
+    * - `invalid-argument`:     (set) The provided value was 0.
+    */
+    keepAliveCount(): number;
+    setKeepAliveCount(value: number): void;
+    /**
+    * Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
+    * 
+    * If the provided value is 0, an `invalid-argument` error is returned.
+    * 
+    * # Typical errors
+    * - `invalid-argument`:     (set) The TTL value must be 1 or higher.
+    */
+    hopLimit(): number;
+    setHopLimit(value: number): void;
+    /**
+    * The kernel buffer space reserved for sends/receives on this socket.
+    * 
+    * If the provided value is 0, an `invalid-argument` error is returned.
+    * Any other value will never cause an error, but it might be silently clamped and/or rounded.
+    * I.e. after setting a value, reading the same setting back may return a different value.
+    * 
+    * Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
+    * 
+    * # Typical errors
+    * - `invalid-argument`:     (set) The provided value was 0.
+    */
+    receiveBufferSize(): bigint;
+    setReceiveBufferSize(value: bigint): void;
+    sendBufferSize(): bigint;
+    setSendBufferSize(value: bigint): void;
+    /**
+    * Create a `pollable` which can be used to poll for, or block on,
+    * completion of any of the asynchronous operations of this socket.
+    * 
+    * When `finish-bind`, `finish-listen`, `finish-connect` or `accept`
+    * return `error(would-block)`, this pollable can be used to wait for
+    * their success or failure, after which the method can be retried.
+    * 
+    * The pollable is not limited to the async operation that happens to be
+    * in progress at the time of calling `subscribe` (if any). Theoretically,
+    * `subscribe` only has to be called once per socket and can then be
+    * (re)used for the remainder of the socket's lifetime.
+    * 
+    * See <https://github.com/WebAssembly/wasi-sockets/blob/main/TcpSocketOperationalSemantics.md#pollable-readiness>
+    * for more information.
+    * 
+    * Note: this function is here for WASI 0.2 only.
+    * It's planned to be removed when `future` is natively supported in Preview3.
+    */
+    subscribe(): Pollable;
+    /**
+    * Initiate a graceful shutdown.
+    * 
+    * - `receive`: The socket is not expecting to receive any data from
+    * the peer. The `input-stream` associated with this socket will be
+    * closed. Any data still in the receive queue at time of calling
+    * this method will be discarded.
+    * - `send`: The socket has no more data to send to the peer. The `output-stream`
+    * associated with this socket will be closed and a FIN packet will be sent.
+    * - `both`: Same effect as `receive` & `send` combined.
+    * 
+    * This function is idempotent; shutting down a direction more than once
+    * has no effect and returns `ok`.
+    * 
+    * The shutdown function does not close (drop) the socket.
+    * 
+    * # Typical errors
+    * - `invalid-state`: The socket is not in the `connected` state. (ENOTCONN)
+    * 
+    * # References
+    * - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html>
+    * - <https://man7.org/linux/man-pages/man2/shutdown.2.html>
+    * - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown>
+    * - <https://man.freebsd.org/cgi/man.cgi?query=shutdown&sektion=2>
+    */
+    shutdown(shutdownType: ShutdownType): void;
+    [Symbol.dispose](): void;
+  }
 }

--- a/templates/service-tcp-echo/service/generated/types/wit.d.ts
+++ b/templates/service-tcp-echo/service/generated/types/wit.d.ts
@@ -1,11 +1,21 @@
-// world wasmcloud:templates/typescript-tcp-service@0.1.0
-export type * as WasiClocksMonotonicClock023 from './interfaces/wasi-clocks-monotonic-clock.js'; // import wasi:clocks/monotonic-clock@0.2.3
-export type * as WasiIoError023 from './interfaces/wasi-io-error.js'; // import wasi:io/error@0.2.3
-export type * as WasiIoPoll020 from './interfaces/wasi-io-poll.js'; // import wasi:io/poll@0.2.0
-export type * as WasiIoPoll023 from './interfaces/wasi-io-poll.js'; // import wasi:io/poll@0.2.3
-export type * as WasiIoStreams023 from './interfaces/wasi-io-streams.js'; // import wasi:io/streams@0.2.3
-export type * as WasiSocketsInstanceNetwork023 from './interfaces/wasi-sockets-instance-network.js'; // import wasi:sockets/instance-network@0.2.3
-export type * as WasiSocketsNetwork023 from './interfaces/wasi-sockets-network.js'; // import wasi:sockets/network@0.2.3
-export type * as WasiSocketsTcpCreateSocket023 from './interfaces/wasi-sockets-tcp-create-socket.js'; // import wasi:sockets/tcp-create-socket@0.2.3
-export type * as WasiSocketsTcp023 from './interfaces/wasi-sockets-tcp.js'; // import wasi:sockets/tcp@0.2.3
-export * as run from './interfaces/wasi-cli-run.js'; // export wasi:cli/run@0.2.0
+/// <reference path="./interfaces/wasi-cli-run.d.ts" />
+/// <reference path="./interfaces/wasi-clocks-monotonic-clock.d.ts" />
+/// <reference path="./interfaces/wasi-io-error.d.ts" />
+/// <reference path="./interfaces/wasi-io-poll.d.ts" />
+/// <reference path="./interfaces/wasi-io-streams.d.ts" />
+/// <reference path="./interfaces/wasi-sockets-instance-network.d.ts" />
+/// <reference path="./interfaces/wasi-sockets-network.d.ts" />
+/// <reference path="./interfaces/wasi-sockets-tcp-create-socket.d.ts" />
+/// <reference path="./interfaces/wasi-sockets-tcp.d.ts" />
+declare module 'wasmcloud:templates/typescript-tcp-service@0.1.0' {
+  export type * as WasiClocksMonotonicClock023 from 'wasi:clocks/monotonic-clock@0.2.3'; // import wasi:clocks/monotonic-clock@0.2.3
+  export type * as WasiIoError023 from 'wasi:io/error@0.2.3'; // import wasi:io/error@0.2.3
+  export type * as WasiIoPoll020 from 'wasi:io/poll@0.2.0'; // import wasi:io/poll@0.2.0
+  export type * as WasiIoPoll023 from 'wasi:io/poll@0.2.3'; // import wasi:io/poll@0.2.3
+  export type * as WasiIoStreams023 from 'wasi:io/streams@0.2.3'; // import wasi:io/streams@0.2.3
+  export type * as WasiSocketsInstanceNetwork023 from 'wasi:sockets/instance-network@0.2.3'; // import wasi:sockets/instance-network@0.2.3
+  export type * as WasiSocketsNetwork023 from 'wasi:sockets/network@0.2.3'; // import wasi:sockets/network@0.2.3
+  export type * as WasiSocketsTcpCreateSocket023 from 'wasi:sockets/tcp-create-socket@0.2.3'; // import wasi:sockets/tcp-create-socket@0.2.3
+  export type * as WasiSocketsTcp023 from 'wasi:sockets/tcp@0.2.3'; // import wasi:sockets/tcp@0.2.3
+  export * as run from 'wasi:cli/run@0.2.0'; // export wasi:cli/run@0.2.0
+}

--- a/templates/service-tcp-echo/service/src/service.ts
+++ b/templates/service-tcp-echo/service/src/service.ts
@@ -25,9 +25,7 @@
  *   Uint8Array. Throws with { tag: 'closed' } on EOF.
  */
 
-// @ts-expect-error — types generated after running npm run setup:wit
 import { instanceNetwork } from 'wasi:sockets/instance-network@0.2.3';
-// @ts-expect-error
 import { createTcpSocket } from 'wasi:sockets/tcp-create-socket@0.2.3';
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
- jco guest-types generates ambient module declarations for bare `wasi:`/`wasmcloud:` specifiers, so `@ts-expect-error` is no longer needed
- Removes stale directives from 6 template files (kv, blobstore, http-api, task-worker, tcp-echo component + service)
- In task-worker, imports `BrokerMessage` from `wasmcloud:messaging/types` instead of redeclaring it locally
- Regenerates stale committed `generated/types/` in service-tcp-echo to the current format