### PR TITLE
docs(readme): fix broken template scaffold command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,12 @@ wash new https://github.com/wasmCloud/typescript.git --name my-project --subfold
 | [http-hello-world-hono](./templates/http-hello-world-hono/)               | Minimal HTTP server component using Hono                           |
 | [http-hello-world-fetch](./templates/http-hello-world-fetch/)             | Minimal HTTP server component using the `fetch()` API              |
 | [http-client](./templates/http-client/)                                   | Component that makes outgoing HTTP requests                        |
+| [http-api-with-distributed-workloads](./templates/http-api-with-distributed-workloads/) | HTTP API + worker template demonstrating distributed workloads via `wasmcloud:messaging` |
 | [http-handler-hono](./templates/http-handler-hono/)                       | HTTP handler component powered by Hono                             |
 | [http-blobstore-handler-hono](./templates/http-blobstore-handler-hono/)   | HTTP handler component powered by Hono, backed by `wasi:blobstore` |
+| [http-filesystem-handler-hono](./templates/http-filesystem-handler-hono/) | HTTP handler component powered by Hono, backed by `wasi:filesystem` |
 | [http-kv-handler-hono](./templates/http-kv-handler-hono/)                 | HTTP handler component powered by Hono, backed by `wasi:keyvalue`  |
+| [http-logging-handler-hono](./templates/http-logging-handler-hono/)       | HTTP handler component powered by Hono, backed by `wasi:logging`   |
 | [service-tcp-echo](./templates/service-tcp-echo/)                         | Service + component template demonstrating `wasi:sockets` TCP      |
 
 See the [templates README](./templates/README.md) for more details.

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,8 +11,11 @@ Example components for building wasmCloud applications with TypeScript.
 | [http-server-with-hono](./components/http-server-with-hono/) | HTTP server component with routing powered by [Hono](https://hono.dev) |
 | [http-streaming](./components/http-streaming/) | HTTP component that streams a response using `wasi:io` primitives |
 | [http-axios](./components/http-axios/) | Component that makes outgoing HTTP requests using [Axios](https://axios-http.com) |
+| [http-stdio](./components/http-stdio/) | HTTP component that demonstrates writing to stdout and stderr via `wasi:cli` |
 | [bundled-esbuild](./components/bundled-esbuild/) | TypeScript component bundled with [esbuild](https://esbuild.github.io) |
 | [bundled-rsbuild](./components/bundled-rsbuild/) | TypeScript component bundled with [Rsbuild](https://rsbuild.dev) |
+| [wasi-config-from-k8s-env](./components/wasi-config-from-k8s-env/) | HTTP component that reads configuration via `wasi:config/store` |
+| [webgpu-tensorflow](./components/webgpu-tensorflow/) | Service + component example for GPU-accelerated TensorFlow.js style transfer |
 
 ## Example Structure
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -9,9 +9,12 @@ Project templates for building wasmCloud components with TypeScript.
 | [http-hello-world-hono](./http-hello-world-hono/)             | Minimal HTTP server component using Hono                          |
 | [http-hello-world-fetch](./http-hello-world-fetch/)           | Minimal HTTP server component using the `fetch()` API             |
 | [http-client](./http-client/)                                 | Component that makes outgoing HTTP requests                       |
+| [http-api-with-distributed-workloads](./http-api-with-distributed-workloads/) | HTTP API + worker template demonstrating distributed workloads via `wasmcloud:messaging` |
 | [http-handler-hono](./http-handler-hono/)                     | HTTP handler component powered by Hono                            |
 | [http-blobstore-handler-hono](./http-blobstore-handler-hono/) | HTTP handler component powered by Hono, backed by `wasi:blobstore`|
+| [http-filesystem-handler-hono](./http-filesystem-handler-hono/) | HTTP handler component powered by Hono, backed by `wasi:filesystem` |
 | [http-kv-handler-hono](./http-kv-handler-hono/)               | HTTP handler component powered by Hono, backed by `wasi:keyvalue`  |
+| [http-logging-handler-hono](./http-logging-handler-hono/)     | HTTP handler component powered by Hono, backed by `wasi:logging`  |
 | [service-tcp-echo](./service-tcp-echo/)                       | Service + component template demonstrating `wasi:sockets` TCP      |
 
 ## Template Structure

--- a/templates/http-hello-world-fetch/README.md
+++ b/templates/http-hello-world-fetch/README.md
@@ -20,11 +20,11 @@ A minimal WebAssembly component built with [TypeScript][ts] that responds to HTT
 Use `wash new` to scaffold a new wasmCloud component project:
 
 ```shell
-wash new https://github.com/wasmCloud/typescript.git --name http-hello-world --subfolder templates/http-hello-world
+wash new https://github.com/wasmCloud/typescript.git --name http-hello-world-fetch --subfolder templates/http-hello-world-fetch
 ```
 
 ```shell
-cd http-hello-world
+cd http-hello-world-fetch
 ```
 
 To build this project and run in a hot-reloading development loop, run `npm run dev` from this directory:


### PR DESCRIPTION
Fixes a broken `wash new` command in `templates/http-hello-world-fetch/README.md`.
Right now it points at `templates/http-hello-world`, but that folder is not in this repo, so copy paste hits a wall.

Also syncs the root, template, and example README lists with the dirs that are actually shipped here. they were a bit out of date too.

Repro
1. Open `templates/http-hello-world-fetch/README.md`
2. Run `wash new https://github.com/wasmCloud/typescript.git --name http-hello-world --subfolder templates/http-hello-world`
3. It fails because that subfolder does not exist

Fix
Use `templates/http-hello-world-fetch` in the command and update the stale README indexes.