### PR TITLE
chore: CODEOWNERS for templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,3 +13,6 @@
 
 examples @wasmCloud/examples-maintainers @wasmCloud/typescript-maintainers
 examples/**/README.md @wasmCloud/docs-maintainers
+
+templates @wasmCloud/examples-maintainers @wasmCloud/typescript-maintainers
+templates/**/README.md @wasmCloud/docs-maintainers


### PR DESCRIPTION
Without this, we require org-maintainer for template changes. See https://github.com/wasmCloud/typescript/pull/658
