### PR TITLE
fix(templates): declare allowedHosts for http-client outbound demo

### DIFF
--- a/templates/http-client/.wash/config.yaml
+++ b/templates/http-client/.wash/config.yaml
@@ -4,3 +4,10 @@ new:
 build:
   command: npm run build
   component_path: dist/http_client.wasm
+
+# Outbound HTTP is gated by the host runtime. Hosts listed here are
+# allowed for this component; add new hosts before targeting them via
+# the `?url=URL` override.
+workload:
+  allowedHosts:
+    - httpbin.org

--- a/templates/http-client/README.md
+++ b/templates/http-client/README.md
@@ -48,6 +48,8 @@ npm run dev
 
 All endpoints support the `?url=URL` query parameter to specify a custom target URL.
 
+> **Configuring outbound hosts.** Outbound HTTP is gated by the host runtime; hosts listed in `workload.allowedHosts` in [.wash/config.yaml](.wash/config.yaml) are allowed. The template ships with `httpbin.org` to match the default demo endpoints; add any additional hosts you plan to hit via `?url=URL`.
+
 ## Features
 
 ### 1. Multiple HTTP Methods


### PR DESCRIPTION
On wash 2.5.x, the `templates/http-client` demo (httpbin.org) fails with HttpRequestDenied out of the box. Updates to declare the target host and add a README note.